### PR TITLE
Removes navwalker.php from scanning by Travis or CodeClimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,4 +20,5 @@ ratings:
   - "**.inc"
 exclude_paths:
 - libs/**/*
+- navwalker.php
 - node_modules/**/*

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -8,6 +8,7 @@
 
 	<!-- Probably need to exclude the libs directory (externally-written code) -->
 	<exclude-pattern>/libs/*</exclude-pattern>
+	<exclude-pattern>/navwalker.php</exclude-pattern>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">


### PR DESCRIPTION
Ideally, this should be accomplished by moving navwalker into libs/ - but failing that step, this removes navwalker.php from being scanned by our code review tools.

Asking @PBruk for a code review / strategy check

Signed-off-by: Matt Bernhardt <mjbernha@mit.edu>