### PR TITLE
Removes navwalker.php from scanning by Travis or CodeClimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,4 +20,5 @@ ratings:
   - "**.inc"
 exclude_paths:
 - libs/**/*
+- navwalker.php
 - node_modules/**/*

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -8,6 +8,7 @@
 
 	<!-- Probably need to exclude the libs directory (externally-written code) -->
 	<exclude-pattern>/libs/*</exclude-pattern>
+	<exclude-pattern>/navwalker.php</exclude-pattern>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">


### PR DESCRIPTION
Ideally, this should be accomplished by moving navwalker into libs/

@PBruk can I ask for a code review of this, or a check on the strategy of masking Navwalker from review? IIRC you said the file wouldn't load correctly if you put it in the libs/ directory?

Signed-off-by: Matt Bernhardt <mjbernha@mit.edu>