### PR TITLE
Autofix applied to whitespace only

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,9 +1,9 @@
 <?php include("../../../wp-blog-header.php"); ?>
 <?php
-	
+
 	$location = $_GET["location"];
-	
+
 	$export = getExport($location);
-	
+
 	echo json_encode($export);
 ?>

--- a/content-full-no.php
+++ b/content-full-no.php
@@ -20,7 +20,7 @@ global $isRoot;
 			
 			
 			<div class="entry-content">
-				<?php if ( !$isRoot ) : ?>
+				<?php if ( ! $isRoot ) : ?>
 				<h1><?php the_title(); ?></h1>
 				<?php endif; ?>
 				<?php the_content(); ?>

--- a/content-full-no.php
+++ b/content-full-no.php
@@ -11,7 +11,7 @@ global $isRoot;
 
 		<div class="content-page">
 		
-			<?php if (has_post_thumbnail()): ?>
+			<?php if ( has_post_thumbnail() ) : ?>
 			<div class="featuredImage">
 				<?php echo the_post_thumbnail(700, 300); ?>
 			
@@ -20,7 +20,7 @@ global $isRoot;
 			
 			
 			<div class="entry-content">
-				<?php if (!$isRoot): ?>
+				<?php if ( !$isRoot ) : ?>
 				<h1><?php the_title(); ?></h1>
 				<?php endif; ?>
 				<?php the_content(); ?>

--- a/content-hour-row.php
+++ b/content-hour-row.php
@@ -1,44 +1,44 @@
-						<?php 
+<?php
 							global $rowOdd, $arDays, $today, $now;
 							$mapPage = "/locations/#!";
-							
+
 							$next = "";
-							
+
 							$locationId = get_the_ID();
 							$slug = $post->post_name;
-							
+
 							$subject = cf("subject");
 							$phone = cf("phone");
 							$building = cf("building");
 							$study24 = get_field("study_24");
-							
+
 							$noHours = cf("no_hours");
-							
+
 							$displayPage = get_field("display_page");
 							$pageID = $displayPage->ID;
 							$pageLink = get_permalink($pageID);
-							
+
 							$temp = $post;
 
 							$hasHours = hasHours($locationId, date("Y-m-d", $today));
 							//$hasHours = 1;
 							//$hoursToday = getHoursToday($locationId);
 							//$isOpen = getOpen($locationId);
-							$post = $temp;							
-							
+							$post = $temp;
+
 							$showSpecial = 1;
 							$showMobileSpecial = 1;
 							$alert = trim(get_field("alert"));
-							
-							//if ($hasHours && $noHours != 1): 
-							if ($noHours != 1): 
-							
+
+							//if ($hasHours && $noHours != 1):
+							if ($noHours != 1):
+
 								if ($rowOdd=="even") {
 									$rowOdd = "";
 								} else {
 									$rowOdd = "even";
 								}
-								
+
 								$firstDay = " firstDisplay";
 							?>						
 								<tr class="<?php echo $rowOdd; ?>">
@@ -59,53 +59,53 @@
 											<b>Today</b><br/>
 										<?php
 											$curDay = $now;
-											
-											$temp = $post;									
-											
+
+											$temp = $post;
+
 											//echo "S: ".date("Y-m-d", $today)." ";
-											
+
 											$message = getMessageDay($locationId, $today);
-											
+
 											if ($message != "" ) {
-												
+
 												if ($showMobileSpecial == 1) {
 													$showMobileSpecial = 0;
-																							
+
 													$msgStart = strtotime($message["start"]);
 													$msgEnd = strtotime($message["end"]);
 													$msgName = $message["name"];
-													
-													$msgClass = "message"; 
-													
-													
+
+													$msgClass = "message";
+
+
 													if ($msgStart == $curDay) {
 														$msgClass .= " msgStart";
 													}
-													
+
 													if ($msgStart < $curDay) {
 														$msgClass .= " msgContinued";
 													}
-													
+
 													if ($msgEnd == $curDay) {
 														$msgClass .= " msgEnd";
 													}
-													
+
 													if ($msgEnd <= $arDays[6]) {
 														$msgClass .= " msgEnds";
 													}
-													
+
 													$end = min($msgEnd, $arDays[6]);
-													
+
 													$diff = floor(($end - $curDay)/(60*60*24))+1;
-													
+
 													$msgClass .= " msgSpan".$diff;
-												
+
 													echo "<div class='tdInside'><div class='$msgClass'>$msgName</div></div>";
 												}
 											} else {
 												echo getMobileHoursDay($locationId, $curDay);
 											}
-											$post = $temp;												
+											$post = $temp;
 										?>
 										</div>		
 										-->										
@@ -120,7 +120,7 @@
 									<?php for($i=0;$i<=6;$i++) { ?>
 										<?php
 											$curDay = $arDays[$i];
-											
+
 											if ($curDay == $now) {
 												$class = "cur";
 												$next = "curAfter";
@@ -131,64 +131,64 @@
 										?>
 									<td class="<?php echo $class.$firstDay; ?>">
 										
-								<?php		
+								<?php
 								$firstDay = "";
-								$temp = $post;									
-								
+								$temp = $post;
+
 								//echo "B: ".date("Y-m-d", $curDay)." ";
-								
+
 								$message = getMessageDay($locationId, $curDay);
-								
+
 								//print_r($message);
-								
+
 								if ($message != "" ) {
-									
+
 									if ($showSpecial == 1) {
-										
+
 										$showSpecial = 0;
-																				
+
 										$msgStart = strtotime($message["start"]);
 										$msgEnd = strtotime($message["end"]);
 										$msgName = $message["name"];
-										
-										$msgClass = "message"; 
-										
-										
+
+										$msgClass = "message";
+
+
 										if ($msgStart == $curDay) {
 											$msgClass .= " msgStart";
 										}
-										
+
 										if ($msgStart < $curDay) {
 											$msgClass .= " msgContinued";
 										}
-										
+
 										if ($msgEnd == $curDay) {
 											$msgClass .= " msgEnd";
 										}
-										
+
 										if ($msgEnd <= $arDays[6]) {
 											$msgClass .= " msgEnds";
 										}
-										
+
 										$end = min($msgEnd, $arDays[6]);
-										
+
 										$diff = floor(($end - $curDay)/(60*60*24))+1;
-										
+
 										$msgClass .= " msgSpan".$diff;
-									
+
 										echo "<div class='tdInside'><div class='$msgClass'>$msgName</div></div>";
 									}
 								} else {
 									echo "<div class='mobileHourDay'><b>".date("D", $curDay)."<br/>".date("n/j", $curDay)."</b><br/>".getMobileHoursDay($locationId, $curDay)."</div>";
 									echo "<div class='fullHourDay'>".getHoursDay($locationId, $curDay)."</div>";
 								}
-								$post = $temp;									
+								$post = $temp;
 								?>	
 										
 									</td>
 									<?php } ?>
 
 								</tr>
-							<?php 
+							<?php
 							endif; // has hours
 							?>

--- a/content-hour-row.php
+++ b/content-hour-row.php
@@ -33,7 +33,7 @@
 							//if ($hasHours && $noHours != 1):
 							if ( $noHours != 1 ) :
 
-								if ( $rowOdd=="even" ) {
+								if ( $rowOdd == "even" ) {
 									$rowOdd = "";
 								} else {
 									$rowOdd = "even";
@@ -96,7 +96,7 @@
 
 													$end = min($msgEnd, $arDays[6]);
 
-													$diff = floor(($end - $curDay)/(60*60*24))+1;
+													$diff = floor(($end - $curDay) / (60 * 60 * 24)) + 1;
 
 													$msgClass .= " msgSpan".$diff;
 
@@ -117,7 +117,7 @@
 										
 									</td>
 	
-									<?php for ( $i=0;$i<=6;$i++ ) { ?>
+									<?php for ( $i = 0;$i <= 6;$i++ ) { ?>
 										<?php
 											$curDay = $arDays[$i];
 
@@ -172,7 +172,7 @@
 
 										$end = min($msgEnd, $arDays[6]);
 
-										$diff = floor(($end - $curDay)/(60*60*24))+1;
+										$diff = floor(($end - $curDay) / (60 * 60 * 24)) + 1;
 
 										$msgClass .= " msgSpan".$diff;
 

--- a/content-hour-row.php
+++ b/content-hour-row.php
@@ -31,9 +31,9 @@
 							$alert = trim(get_field("alert"));
 
 							//if ($hasHours && $noHours != 1):
-							if ($noHours != 1):
+							if ( $noHours != 1 ) :
 
-								if ($rowOdd=="even") {
+								if ( $rowOdd=="even" ) {
 									$rowOdd = "";
 								} else {
 									$rowOdd = "even";
@@ -45,12 +45,12 @@
 									<td class="name">
 										<div class="nameHolder">
 											<h3><a href="<?php echo $pageLink; ?>"><?php the_title(); ?></a></h3>
-											<?php if ($phone != ""): ?>
+											<?php if ( $phone != "" ) : ?>
 												<?php echo $phone ?><br/>
 											<?php endif; ?>
 										</div>
 										<a class="map" href="<?php echo $mapPage.$slug; ?>">Map: <?php echo $building ?></a>									
-										<?php if ($study24 == 1): ?>
+										<?php if ( $study24 == 1 ) : ?>
 											<a class="space247" href="/study/24x7/" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 										<?php endif; ?>
 										<!--
@@ -66,9 +66,9 @@
 
 											$message = getMessageDay($locationId, $today);
 
-											if ($message != "" ) {
+											if ( $message != "" ) {
 
-												if ($showMobileSpecial == 1) {
+												if ( $showMobileSpecial == 1 ) {
 													$showMobileSpecial = 0;
 
 													$msgStart = strtotime($message["start"]);
@@ -78,19 +78,19 @@
 													$msgClass = "message";
 
 
-													if ($msgStart == $curDay) {
+													if ( $msgStart == $curDay ) {
 														$msgClass .= " msgStart";
 													}
 
-													if ($msgStart < $curDay) {
+													if ( $msgStart < $curDay ) {
 														$msgClass .= " msgContinued";
 													}
 
-													if ($msgEnd == $curDay) {
+													if ( $msgEnd == $curDay ) {
 														$msgClass .= " msgEnd";
 													}
 
-													if ($msgEnd <= $arDays[6]) {
+													if ( $msgEnd <= $arDays[6] ) {
 														$msgClass .= " msgEnds";
 													}
 
@@ -109,7 +109,7 @@
 										?>
 										</div>		
 										-->										
-										<?php if ($alert != ""): ?>
+										<?php if ( $alert != "" ) : ?>
 											<div class="libraryAlert">
 												<?php echo '<i class="icon-exclamation-sign"></i>'.$alert; ?>
 											</div>
@@ -117,11 +117,11 @@
 										
 									</td>
 	
-									<?php for($i=0;$i<=6;$i++) { ?>
+									<?php for ( $i=0;$i<=6;$i++ ) { ?>
 										<?php
 											$curDay = $arDays[$i];
 
-											if ($curDay == $now) {
+											if ( $curDay == $now ) {
 												$class = "cur";
 												$next = "curAfter";
 											} else {
@@ -141,9 +141,9 @@
 
 								//print_r($message);
 
-								if ($message != "" ) {
+								if ( $message != "" ) {
 
-									if ($showSpecial == 1) {
+									if ( $showSpecial == 1 ) {
 
 										$showSpecial = 0;
 
@@ -154,19 +154,19 @@
 										$msgClass = "message";
 
 
-										if ($msgStart == $curDay) {
+										if ( $msgStart == $curDay ) {
 											$msgClass .= " msgStart";
 										}
 
-										if ($msgStart < $curDay) {
+										if ( $msgStart < $curDay ) {
 											$msgClass .= " msgContinued";
 										}
 
-										if ($msgEnd == $curDay) {
+										if ( $msgEnd == $curDay ) {
 											$msgClass .= " msgEnd";
 										}
 
-										if ($msgEnd <= $arDays[6]) {
+										if ( $msgEnd <= $arDays[6] ) {
 											$msgClass .= " msgEnds";
 										}
 

--- a/content-hours.php
+++ b/content-hours.php
@@ -58,7 +58,7 @@
 					<a href="#">See all hours <i class="icon-arrow-right"></i></a>
 				</div>				
 				
-				<?php if ($alert != ""): ?>
+				<?php if ( $alert != "" ) : ?>
 				<div class="libraryAlert">
 					<?php echo $alert; ?>
 				</div>
@@ -68,17 +68,17 @@
 			<div id="content" class="locationContent">
 				<div id="mainContent">
 					
-					<?php if ($title1 != "" || $title2 != ""): ?>
+					<?php if ( $title1 != "" || $title2 != "" ) : ?>
 						<?php $noTab = "";  ?>
 					<ul class="tabnav">
-						<?php if ($title1 != ""): ?>
+						<?php if ( $title1 != "" ) : ?>
 						<li class="active"><a href="#tab1"><?php echo $title1 ?><div><?php echo $subtitle1 ?></div></a></li>
 						<?php endif; ?>
-						<?php if ($title2 != ""): ?>
+						<?php if ( $title2 != "" ) : ?>
 						<li><a href="#tab2"><?php echo $title2 ?><div><?php echo $subtitle2 ?></div></a></li>
 						<?php endif; ?>
 					</ul>
-					<?php else: ?>
+					<?php else : ?>
 						<?php $noTab = " noTab";  ?>
 					<?php endif; ?>
 					<div class="tabcontent <?php echo $noTab ?>">
@@ -87,7 +87,7 @@
 								<div class="span4 first">
 								
 									<?php
-										if ($arexpert) {
+										if ( $arexpert ) {
 											$expertIndex = array_rand($arexpert);
 											$expert = $arexpert[$expertIndex];
 
@@ -97,7 +97,7 @@
 											//$url = $expert->guid;
 											$url = get_post_meta($expert->ID, "expert_url", 1);
 
-											if (has_post_thumbnail($expert->ID)) {
+											if ( has_post_thumbnail($expert->ID) ) {
 												$thumb = get_the_post_thumbnail($expert->ID, array(108,108));
 											} else {
 												$thumb = "";
@@ -105,7 +105,7 @@
 
 									?>
 									<div class="profile">
-										<?php if ($thumb != ""):
+										<?php if ( $thumb != "" ) :
 											echo $thumb;
 										endif; ?>
 										<div class="profileContent">
@@ -133,7 +133,7 @@
 								</div>
 							</div>
 						</div>
-						<?php if ($title2 != ""): ?>
+						<?php if ( $title2 != "" ) : ?>
 						
 						<div class="tab" id="tab2">
 							<div class="row">
@@ -169,12 +169,12 @@
 								<li><a href="#">Get books, articles, and more...</a></li>
 							</ul>
 						</div>
-						<?php $val = $spaces; if ($val != ""): ?>
+						<?php $val = $spaces; if ( $val != "" ) : ?>
 						<div class="widget">
 							<?php echo $val; ?>
 						</div>
 						<?php endif; ?>
-						<?php $val = $equipment; if ($val != ""): ?>
+						<?php $val = $equipment; if ( $val != "" ) : ?>
 						<div class="widget">
 							<?php echo $val; ?>
 						</div>

--- a/content-hours.php
+++ b/content-hours.php
@@ -1,25 +1,25 @@
-		<?php
+<?php
 			$subject = cf("subject");
 			$phone = cf("phone");
 			$building = cf("building");
 			$spaces = cf("group_spaces");
 			$equipment = cf("equipment");
 			$arexpert = get_field("expert");
-			
+
 			$title1 = cf("tab_1_title");
 			$subtitle1 = cf("tab_1_subtitle");
 			$content1left = get_field("tab_1_content_left");
 			$content1 = get_field("tab_1_content");
-			
+
 			$title2 = cf("tab_2_title");
 			$subtitle2 = cf("tab_2_subtitle");
 			$content2left = get_field("tab_2_content_left");
 			$content2 = get_field("tab_2_content");
-			
+
 			$displayPage = get_field("display_page");
 			$pageID = $displayPage->ID;
 			$pageLink = get_permalink($pageID);
-			
+
 			$alert = get_field("alert");
 		?>
 		
@@ -90,22 +90,22 @@
 										if ($arexpert) {
 											$expertIndex = array_rand($arexpert);
 											$expert = $arexpert[$expertIndex];
-											
-											
+
+
 											$name = $expert->post_title;
 											$bio = $expert->post_excerpt;
 											//$url = $expert->guid;
 											$url = get_post_meta($expert->ID, "expert_url", 1);
-											
+
 											if (has_post_thumbnail($expert->ID)) {
 												$thumb = get_the_post_thumbnail($expert->ID, array(108,108));
 											} else {
 												$thumb = "";
 											}
-											
+
 									?>
 									<div class="profile">
-										<?php if ($thumb != ""): 
+										<?php if ($thumb != ""):
 											echo $thumb;
 										endif; ?>
 										<div class="profileContent">

--- a/content-location.php
+++ b/content-location.php
@@ -37,7 +37,7 @@
 
 
 	$reserveText = get_field("reserve_text");
-	if ($reserveText == "") {
+	if ( $reserveText == "" ) {
 		$reserveText = "Reserve Group Study Space";
 	}
 	$reserveUrl = get_field("reserve_url");
@@ -51,7 +51,7 @@
 	$numMain = 6;
 	$arMain = array();
 
-	for($i=1;$i<=$numMain;$i++) {
+	for ( $i=1;$i<=$numMain;$i++ ) {
 		$img = get_field("main_image".$i, $locationId);
 		if ($img != "")
 			$arMain[] = $img;
@@ -60,16 +60,16 @@
 	$numSub = 8;
 	$arSub = array();
 	$subs = 0;
-	for($i=1;$i<=$numSub;$i++) {
+	for ( $i=1;$i<=$numSub;$i++ ) {
 		$img = get_field("sub_image".$i, $locationId);
-		if ($img != "") {
+		if ( $img != "" ) {
 			$subs++;
 			$arSub[] = $img;
 		}
 	}
 
 	$strLocation = "";
-	if ($subs <= 0) {
+	if ( $subs <= 0 ) {
 		$strLocation = "noThumbs";
 	}
 
@@ -83,7 +83,7 @@
 <div class="libraryAlertTop">
 <?php
 					include(locate_template('inc/alert.php'));
-					if ($showAlert == 0 && $alertTitle != "") {
+					if ( $showAlert == 0 && $alertTitle != "" ) {
 						echo '<div class="libraryAlert">'.'<div class="location--alerts flex-container"><svg class="icon-exclamation-circle width="2048" height="2048" viewBox="0 0 2048 2048" xmlns="http://www.w3.org/2000/svg"><path d="M1024 256q209 0 385.5 103t279.5 279.5 103 385.5-103 385.5-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103zm128 1247v-190q0-14-9-23.5t-22-9.5h-192q-13 0-23 10t-10 23v190q0 13 10 23t23 10h192q13 0 22-9.5t9-23.5zm-2-344l18-621q0-12-10-18-10-8-24-8h-220q-14 0-24 8-10 6-10 18l17 621q0 10 10 17.5t24 7.5h185q14 0 23.5-7.5t10.5-17.5z"/></svg>'.'<div class="alertText">'.'<h3>'.$alertTitle.'</h3>'.'<p>'.$alertContent.'</p>'.'</div>'.'</div>'.'</div>';
 					}
 				?>
@@ -100,7 +100,7 @@
 					</h1>
 					<div class="info-more">
 						<a href="tel:<?php echo $phone; ?>" class="phone"><?php echo $phone ?></a> |
-	                    	<?php if($email): ?>
+	                    	<?php if ( $email ) : ?>
 						<a href="mailto:<?php echo $email; ?>" class="email"><?php echo $email ?></a> |
 	                    	<?php endif; ?>
 						<a href="<?php echo $mapPage.$slug; ?>">Room: <?php echo $building ?> <i class="icon-arrow-right"></i></a>
@@ -109,7 +109,7 @@
 
 				<div class="hours-today">
 					<span>Today's hours: <strong data-location-hours="<?php the_title(); ?>"></strong></span>
-					<?php if ($study24 == 1): ?>
+					<?php if ( $study24 == 1 ) : ?>
 						| <a class="study-24-7" href="<?php echo $gStudy24Url; ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 					<?php endif; ?>
 					<a href="/hours" class="link-hours-all">See all hours <i class="icon-arrow-right"></i></a>
@@ -123,7 +123,7 @@
 						<?php
 							$val = $arMain[array_rand($arMain)];
 						?>
-						<?php if ($val != ""): ?>
+						<?php if ( $val != "" ) : ?>
 						<img src="<?php echo $val; ?>" data-thumb="<?php echo $val; ?>" alt="<?php the_title(); ?>" />
 						<?php endif; ?>
 					</div>
@@ -135,17 +135,17 @@
 	<div class="content-main flex-container group <?php echo $strLocation; ?>">
 		<div class="col-1 content-page">
 
-			<?php if ($title1 != "" || $title2 != ""): ?>
+			<?php if ( $title1 != "" || $title2 != "" ) : ?>
 				<?php $noTab = "";  ?>
 			<ul class="tabnav">
-				<?php if ($title1 != ""): ?>
+				<?php if ( $title1 != "" ) : ?>
 				<li class="active tab1st"><h2 class="title-tab"><a href="#tab1"><?php echo $title1 ?><span class="title-sub hidden-mobile"><?php echo $subtitle1 ?></span class="title-sub"></a></h2></li>
 				<?php endif; ?>
-				<?php if ($title2 != ""): ?>
+				<?php if ( $title2 != "" ) : ?>
 				<li class="tab2nd"><h2 class="title-tab"><a href="#tab2"><?php echo $title2 ?><span class="title-sub hidden-mobile"><?php echo $subtitle2 ?></span class="title-sub"></a></h2></li>
 				<?php endif; ?>
 			</ul>
-			<?php else: ?>
+			<?php else : ?>
 				<?php $noTab = " noTab";  ?>
 			<?php endif; ?>
 
@@ -153,10 +153,10 @@
 
 				<div class="tab tab1 active flex-container group" id="tab1">
 
-						<div class="flex-item first group <?php if($content1wide): ?>span7 wideColumn<?php else: ?>span4<?php endif; ?>">
+						<div class="flex-item first group <?php if ( $content1wide ) : ?>span7 wideColumn<?php else : ?>span4<?php endif; ?>">
 
 							<?php
-								if ($arexpert) {
+								if ( $arexpert ) {
 									$expertIndex = array_rand($arexpert);
 									$expert = $arexpert[$expertIndex];
 
@@ -166,7 +166,7 @@
 									//$url = $expert->guid;
 									$url = get_post_meta($expert->ID, "expert_url", 1);
 
-									if (has_post_thumbnail($expert->ID)) {
+									if ( has_post_thumbnail($expert->ID) ) {
 										$thumb = get_the_post_thumbnail($expert->ID, array(108,108));
 									} else {
 										$thumb = "";
@@ -174,7 +174,7 @@
 
 							?>
 							<div class="profile flex-container group">
-								<?php if ($thumb != ""):
+								<?php if ( $thumb != "" ) :
 									echo $thumb;
 								endif; ?>
 								<div class="profileContent">
@@ -200,14 +200,14 @@
 						</div>
 
 				</div>
-				<?php if ($title2 != ""): ?>
+				<?php if ( $title2 != "" ) : ?>
 				
 				<div class="tab tab2 flex-container group" id="tab2">
 
-						<div class="flex-item first <?php if($content2wide): ?>span8 wideColumn<?php else: ?>span2<?php endif; ?>">
+						<div class="flex-item first <?php if ( $content2wide ) : ?>span8 wideColumn<?php else : ?>span2<?php endif; ?>">
 						<?php echo $content2left ?>
 						
-						<?php if ($reserveUrl != ""): ?>
+						<?php if ( $reserveUrl != "" ) : ?>
 									<a class="reserve hidden-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
 						<?php endif; ?>
 

--- a/content-location.php
+++ b/content-location.php
@@ -51,7 +51,7 @@
 	$numMain = 6;
 	$arMain = array();
 
-	for ( $i=1;$i<=$numMain;$i++ ) {
+	for ( $i = 1;$i <= $numMain;$i++ ) {
 		$img = get_field("main_image".$i, $locationId);
 		if ($img != "")
 			$arMain[] = $img;
@@ -60,7 +60,7 @@
 	$numSub = 8;
 	$arSub = array();
 	$subs = 0;
-	for ( $i=1;$i<=$numSub;$i++ ) {
+	for ( $i = 1;$i <= $numSub;$i++ ) {
 		$img = get_field("sub_image".$i, $locationId);
 		if ( $img != "" ) {
 			$subs++;

--- a/content-nav-full.php
+++ b/content-nav-full.php
@@ -47,7 +47,7 @@ global $isRoot;
 		
 		
 		<div class="entry-content">
-			<?php if ( !$isRoot ) : ?>
+			<?php if ( ! $isRoot ) : ?>
 			<h2><?php the_title(); ?></h2>
 			<?php endif; ?>
 			

--- a/content-nav-full.php
+++ b/content-nav-full.php
@@ -27,7 +27,7 @@ global $isRoot;
 
 			$menu = wp_get_nav_menu_items($menuName);
 
-			if ($menu) {
+			if ( $menu ) {
 				wp_nav_menu( array( 'menu' => $menuName, 'menu_class' => 'nav-menu' ) );
 			} else {
 				wp_list_pages( $args );
@@ -38,7 +38,7 @@ global $isRoot;
 	</div>
 	<div id="mainContent" class="span9">
 	
-		<?php if (has_post_thumbnail()): ?>
+		<?php if ( has_post_thumbnail() ) : ?>
 		<div class="featuredImage">
 			<?php echo the_post_thumbnail(700, 300); ?>
 		
@@ -47,7 +47,7 @@ global $isRoot;
 		
 		
 		<div class="entry-content">
-			<?php if (!$isRoot): ?>
+			<?php if ( !$isRoot ) : ?>
 			<h2><?php the_title(); ?></h2>
 			<?php endif; ?>
 			

--- a/content-nav-full.php
+++ b/content-nav-full.php
@@ -14,23 +14,23 @@ global $isRoot;
 		<ul>
 		<?php
 			//$pageParent = getParent($post->ID);
-			
+
 			$pageRoot = getRoot($post);
 			$section = get_post($pageRoot);
-						
+
 			$args = array(
 				"child_of" => $pageRoot,
 				"title_li" => "",
 			);
-			
+
 			$menuName = $section->post_name;
-			
+
 			$menu = wp_get_nav_menu_items($menuName);
-			
+
 			if ($menu) {
-				wp_nav_menu( array( 'menu' => $menuName, 'menu_class' => 'nav-menu' ) ); 
+				wp_nav_menu( array( 'menu' => $menuName, 'menu_class' => 'nav-menu' ) );
 			} else {
-				wp_list_pages( $args ); 
+				wp_list_pages( $args );
 			}
 		?>
 		</ul>

--- a/content-page.php
+++ b/content-page.php
@@ -23,7 +23,7 @@ global $isRoot;
 		<div class="col-1 content-page">
 			<div class="entry-content">
 				<div class="entry-page-title">
-				<?php if ( !$isRoot ) : ?>
+				<?php if ( ! $isRoot ) : ?>
 				<h1><?php the_title(); ?></h1>
 				<?php endif; ?>
 				</div>

--- a/content-page.php
+++ b/content-page.php
@@ -6,13 +6,13 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
 
- 
+
+
 global $isRoot;
 
 
- 
+
 ?>
 
 	<?php if (in_category('has-menu')) { ?>

--- a/content-page.php
+++ b/content-page.php
@@ -15,7 +15,7 @@ global $isRoot;
 
 ?>
 
-	<?php if (in_category('has-menu')) { ?>
+	<?php if ( in_category('has-menu') ) { ?>
 		<?php get_template_part('inc/content', 'secmenu'); ?>
 			<?php } ?>
 
@@ -23,7 +23,7 @@ global $isRoot;
 		<div class="col-1 content-page">
 			<div class="entry-content">
 				<div class="entry-page-title">
-				<?php if (!$isRoot): ?>
+				<?php if ( !$isRoot ) : ?>
 				<h1><?php the_title(); ?></h1>
 				<?php endif; ?>
 				</div>

--- a/content-pagefull.php
+++ b/content-pagefull.php
@@ -9,7 +9,7 @@
 global $isRoot;
 ?>
 <div class="col-1 content-page">
-		<?php if (has_post_thumbnail()): ?>
+		<?php if ( has_post_thumbnail() ) : ?>
 		<div class="featuredImage">
 			<?php echo the_post_thumbnail(700, 300); ?>
 		
@@ -18,7 +18,7 @@ global $isRoot;
 		
 		
 		<div class="entry-content">
-			<?php if (!$isRoot): ?>
+			<?php if ( !$isRoot ) : ?>
 			<h2><?php the_title(); ?></h2>
 			<?php endif; ?>
 			<?php the_content(); ?>

--- a/content-pagefull.php
+++ b/content-pagefull.php
@@ -18,7 +18,7 @@ global $isRoot;
 		
 		
 		<div class="entry-content">
-			<?php if ( !$isRoot ) : ?>
+			<?php if ( ! $isRoot ) : ?>
 			<h2><?php the_title(); ?></h2>
 			<?php endif; ?>
 			<?php the_content(); ?>

--- a/content-shortcrumb.php
+++ b/content-shortcrumb.php
@@ -6,13 +6,13 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
 
- 
+
+
 global $isRoot;
 
 
- 
+
 ?>
 
 	<?php if (in_category('has-menu')) { ?>

--- a/content-shortcrumb.php
+++ b/content-shortcrumb.php
@@ -15,7 +15,7 @@ global $isRoot;
 
 ?>
 
-	<?php if (in_category('has-menu')) { ?>
+	<?php if ( in_category('has-menu') ) { ?>
 		<?php get_template_part('inc/content', 'secmenu'); ?>
 			<?php } ?>
 

--- a/functions.php
+++ b/functions.php
@@ -177,11 +177,11 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
 
 	/* Page-specific JS & CSS */
 
-	if ( !is_front_page() || is_child_theme() ) {
+	if ( ! is_front_page() || is_child_theme() ) {
 		wp_enqueue_script('productionJS');
 	}
 
-	if ( is_front_page() && !is_child_theme() ) {
+	if ( is_front_page() && ! is_child_theme() ) {
 		wp_enqueue_script('homeJS');
 	}
 
@@ -441,7 +441,7 @@ function twentytwelve_entry_meta() {
 }
 endif;
 
-if ( !function_exists('is_child_page') ) {
+if ( ! function_exists('is_child_page') ) {
 	function is_child_page() {
 	global $post;     // if outside the loop
 
@@ -560,7 +560,7 @@ function getRoot( $post ) {
 
 	$is_section = get_post_meta($post->ID, "is_section", 1);
 
-	for ( $i=0;$i<count($ar);$i++ ) {
+	for ( $i = 0;$i < count($ar);$i++ ) {
 		$pid = $ar[$i];
 		$is_section = get_post_meta($pid, "is_section", 1);
 		if ( $is_section == 1 ) {
@@ -568,7 +568,7 @@ function getRoot( $post ) {
 		}
 	}
 
-	$max = count($ar)-1;
+	$max = count($ar) -1;
 
 	if ( $max == -1 ) {
 		return $post->ID;
@@ -579,7 +579,7 @@ function getRoot( $post ) {
 }
 
 function the_breadcrumb() {
-	if ( !is_home() ) {
+	if ( ! is_home() ) {
 		echo '<a href="';
 		echo get_option('home');
 		echo '">';
@@ -598,8 +598,8 @@ function the_breadcrumb() {
 }
 
 function wsf_make_link( $url, $anchortext, $title=null, $nofollow=false ) {
-	if ( $title == null ) $title=$anchortext;
-	$nofollow==true ? $rel=' rel="nofollow"' : $rel = '';
+	if ( $title == null ) $title = $anchortext;
+	$nofollow == true ? $rel = ' rel="nofollow"' : $rel = '';
 
 	$link = sprintf( '<a href="%s" title="%s" %s="">%s</a>', $url, $title, $rel, $anchortext );
 	return $link;
@@ -624,7 +624,7 @@ function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
 
 	// Do not show breadcrumbs on home or front pages.
 	// So we will just return quickly
-	if ((is_home() || is_front_page()) && (!$front_page))
+	if ((is_home() || is_front_page()) && ( ! $front_page))
 	  return;
 
 	// Create a constant for the separator, with space padding.
@@ -715,7 +715,7 @@ function getExpert( $expert ) {
 
 }
 
-if ( !function_exists('better_breadcrumbs') ) {
+if ( ! function_exists('better_breadcrumbs') ) {
 
 	function better_breadcrumbs() {
 
@@ -725,7 +725,7 @@ if ( !function_exists('better_breadcrumbs') ) {
 	    echo "<span>Search</span>";
 	  }
 
-	  if ( !is_child_page() && is_page() || is_category() || is_single() ) {
+	  if ( ! is_child_page() && is_page() || is_category() || is_single() ) {
 	    echo "<span>".the_title()."</span>";
 	    return;
 	  }
@@ -742,7 +742,7 @@ if ( !function_exists('better_breadcrumbs') ) {
 	    $pageLink = get_permalink($post);
 	    $childBreadcrumb = $startLink.$pageLink.$endLink.$pageTitle.$closeLink;
 
-		  if ( $parentBreadcrumb !="" && $hideParent != 1 ) {echo "<span>".$parentBreadcrumb."</span>";}
+		  if ( $parentBreadcrumb != "" && $hideParent != 1 ) {echo "<span>".$parentBreadcrumb."</span>";}
 		  if ( $childBreadcrumb != "" ) {echo "<span>".$pageTitle."</span>";}
 		}
 	}
@@ -752,7 +752,7 @@ if ( !function_exists('better_breadcrumbs') ) {
 
 // Check for performance issues
 function no_post_limit( $query ) {
-	if ( is_home() && !is_child_theme() ) {
+	if ( is_home() && ! is_child_theme() ) {
 	// No post limit on homepage
 	$query->set( 'posts_per_page', -1 );
 	return;
@@ -761,7 +761,7 @@ function no_post_limit( $query ) {
 add_action( 'pre_get_posts', 'no_post_limit', 1 );
 
 // Prevent Wordpress from "guessing" redirects instead of showing a 404 page
-if ( !function_exists('stop_404_guessing') ) {
+if ( ! function_exists('stop_404_guessing') ) {
 	add_filter('redirect_canonical', 'stop_404_guessing');
 	function stop_404_guessing( $url ) {
 		if ( is_404() ) {

--- a/functions.php
+++ b/functions.php
@@ -32,7 +32,7 @@ $gStudy24Url = "/study/24x7/";
 
 //$siteRoot = "/var/www/vhosts/seangw.com/mitlibraries";
 $siteRoot = $_SERVER['DOCUMENT_ROOT'];
-foreach(glob($siteRoot."/wp-content/themes/libraries/lib/*.php") as $file) require_once($file);
+foreach (glob($siteRoot."/wp-content/themes/libraries/lib/*.php") as $file) require_once($file);
 
 /**
  * Sets up the content width value based on the theme's design and stylesheet.
@@ -177,45 +177,45 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
 
 	/* Page-specific JS & CSS */
 
-	if (!is_front_page() || is_child_theme()) {
+	if ( !is_front_page() || is_child_theme() ) {
 		wp_enqueue_script('productionJS');
 	}
 
-	if (is_front_page() && !is_child_theme()) {
+	if ( is_front_page() && !is_child_theme() ) {
 		wp_enqueue_script('homeJS');
 	}
 
-	if (is_page('hours')) {
+	if ( is_page('hours') ) {
 		wp_enqueue_style('hours');
 		wp_enqueue_script('hoursJS');
 	}
 
-	if (is_page('locations')) {
+	if ( is_page('locations') ) {
 		wp_enqueue_script('googleMapsAPI');
 		wp_enqueue_script('mapJS');
 		wp_enqueue_script('infobox');
 	}
 
-	if (is_page('search')) {
+	if ( is_page('search') ) {
 		wp_enqueue_script('searchJS');
 	}
 
-	if (is_page('term-hours')) {
+	if ( is_page('term-hours') ) {
 		wp_enqueue_script('term-hours');
 	}
 
-	if (is_page('getit')) {
+	if ( is_page('getit') ) {
 		wp_enqueue_style('get-it');
 	}
 
-	if (is_page_template('nav-maine')) {
+	if ( is_page_template('nav-maine') ) {
 		wp_enqueue_style('jquery.smartmenus.bootstrap');
 		wp_enqueue_script('bootstrap.min');
 		wp_enqueue_script('jquery.smartmenus.bootstrap.min');
 		wp_enqueue_script('jquery.smartmenus');
 	}
 
-	if (in_category('has-menu')) {
+	if ( in_category('has-menu') ) {
 		wp_enqueue_style('libraries-global');
 		wp_enqueue_style('bootstrapCSS');
 		wp_enqueue_script('bootstrap-js');
@@ -441,7 +441,7 @@ function twentytwelve_entry_meta() {
 }
 endif;
 
-if (!function_exists('is_child_page')) {
+if ( !function_exists('is_child_page') ) {
 	function is_child_page() {
 	global $post;     // if outside the loop
 
@@ -484,19 +484,19 @@ function twentytwelve_body_class( $classes ) {
 			$classes[] = 'two-sidebars';
 	}
 
-	if (is_child_theme()) {
+	if ( is_child_theme() ) {
 		$classes[] = 'childTheme';
 	}
 
-	if(is_child_page()) {
+	if ( is_child_page() ) {
 		$classes[] = 'childPage';
 	}
 
-	if (is_page_template('page-selfTitle.php')) {
+	if ( is_page_template('page-selfTitle.php') ) {
 		$classes[] = 'boxSizingOn';
 	}
 
-	if (is_page_template('page-location.php')) {
+	if ( is_page_template('page-location.php') ) {
 		$classes[] = 'locationPage';
 	}
 
@@ -552,25 +552,25 @@ add_action( 'customize_preview_init', 'twentytwelve_customize_preview_js' );
 
 /** Unique for theme **/
 
-function getParent($id) {
+function getParent( $id ) {
 
 }
-function getRoot($post) {
+function getRoot( $post ) {
 	$ar = get_post_ancestors($post);
 
 	$is_section = get_post_meta($post->ID, "is_section", 1);
 
-	for($i=0;$i<count($ar);$i++) {
+	for ( $i=0;$i<count($ar);$i++ ) {
 		$pid = $ar[$i];
 		$is_section = get_post_meta($pid, "is_section", 1);
-		if ($is_section == 1) {
+		if ( $is_section == 1 ) {
 			return $pid;
 		}
 	}
 
 	$max = count($ar)-1;
 
-	if ($max == -1) {
+	if ( $max == -1 ) {
 		return $post->ID;
 	} else {
 		return $ar[$max];
@@ -579,25 +579,25 @@ function getRoot($post) {
 }
 
 function the_breadcrumb() {
-	if (!is_home()) {
+	if ( !is_home() ) {
 		echo '<a href="';
 		echo get_option('home');
 		echo '">';
 		bloginfo('name');
 		echo "</a> &raquo; ";
-		if (is_category() || is_single()) {
+		if ( is_category() || is_single() ) {
 			the_category('title_li=');
-			if (is_single()) {
+			if ( is_single() ) {
 				echo " &raquo; ";
 				the_title();
 			}
-		} elseif (is_page()) {
+		} elseif ( is_page() ) {
 			echo the_title();
 		}
 	}
 }
 
-function wsf_make_link ( $url, $anchortext, $title=null, $nofollow=false ) {
+function wsf_make_link( $url, $anchortext, $title=null, $nofollow=false ) {
 	if ( $title == null ) $title=$anchortext;
 	$nofollow==true ? $rel=' rel="nofollow"' : $rel = '';
 
@@ -611,7 +611,7 @@ function showBreadTitle() {
 	$custom_title = $custom_title[0];
 	//$custom_title = get_field("breadcrumb_override");
 
-	if ($custom_title != "") {
+	if ( $custom_title != "" ) {
 	 echo $custom_title;
 	} else {
 	 the_title();
@@ -624,7 +624,7 @@ function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
 
 	// Do not show breadcrumbs on home or front pages.
 	// So we will just return quickly
-	if((is_home() || is_front_page()) && (!$front_page))
+	if ((is_home() || is_front_page()) && (!$front_page))
 	  return;
 
 	// Create a constant for the separator, with space padding.
@@ -634,19 +634,19 @@ function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
 
 	echo wsf_make_link( get_bloginfo('url'), 'Home', get_bloginfo('name'), true ) . $SEP;
 
-	if(is_single()) {
+	if ( is_single() ) {
 	the_category(', '); echo $SEP;
 	}
-	elseif(is_page()) {
+	elseif ( is_page() ) {
 			$parent_id = $post->post_parent;
 			$parents = array();
-			while($parent_id) {
+			while ( $parent_id ) {
 				$page = get_page($parent_id);
 			$parents[]  = wsf_make_link( get_permalink($page->ID), get_the_title($page->ID) ) . $SEP;
 				$parent_id  = $page->post_parent;
 			}
 			$parents = array_reverse($parents);
-			foreach($parents as $parent) {
+			foreach ( $parents as $parent ) {
 				echo $parent;
 			}
 	}
@@ -657,11 +657,11 @@ function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
 	 echo '</div>';
 }
 
-function cf($name) {
+function cf( $name ) {
 	return get_post_meta( get_the_ID(), $name, true);
 }
 
-function remove_template( $files_to_delete = array() ){
+function remove_template( $files_to_delete = array() ) {
 	global $wp_themes;
 
 	// As convenience, allow a single value to be used as a scalar without wrapping it in a useless array()
@@ -678,9 +678,9 @@ function remove_template( $files_to_delete = array() ){
 	// Note that we're taking a reference to $wp_themes so we can modify it in-place
 	$template_files = &$wp_themes[$current_theme_name]['Template Files'];
 
-	foreach ( $template_files as $file_path ){
-		foreach( $files_to_delete as $file_name ){
-			if ( preg_match( '/\/'.$file_name.'\.[^.]+$/', $file_path ) ){
+	foreach ( $template_files as $file_path ) {
+		foreach ( $files_to_delete as $file_name ) {
+			if ( preg_match( '/\/'.$file_name.'\.[^.]+$/', $file_path ) ) {
 				$key = array_search( $file_path, $template_files );
 				if ( $key ) unset ( $template_files[$key] );
 			}
@@ -688,13 +688,13 @@ function remove_template( $files_to_delete = array() ){
 	}
 }
 
-function menuWithParent($menu, $par) {
+function menuWithParent( $menu, $par ) {
 	$menu_items = wp_get_nav_menu_items($menu);
 
 	$arOut = array();
 
-	foreach($menu_items as $key => $item) {
-		if ($item->menu_item_parent == $par) {
+	foreach ( $menu_items as $key => $item ) {
+		if ( $item->menu_item_parent == $par ) {
 			array_push($arOut, $item);
 		}
 	}
@@ -703,7 +703,7 @@ function menuWithParent($menu, $par) {
 
 }
 
-function getExpert($expert) {
+function getExpert( $expert ) {
 	$args = array(
 		'post_type' => 'expert',
 		'p' => $expert
@@ -715,22 +715,22 @@ function getExpert($expert) {
 
 }
 
-if (!function_exists('better_breadcrumbs')) {
+if ( !function_exists('better_breadcrumbs') ) {
 
 	function better_breadcrumbs() {
 
 	  global $post;
 
-	  if(is_search()) {
+	  if ( is_search() ) {
 	    echo "<span>Search</span>";
 	  }
 
-	  if(!is_child_page() && is_page() || is_category() || is_single()) {
+	  if ( !is_child_page() && is_page() || is_category() || is_single() ) {
 	    echo "<span>".the_title()."</span>";
 	    return;
 	  }
 
-	  if(is_child_page()) {
+	  if ( is_child_page() ) {
 	  	$hideParent = get_field('hide_parent_breadcrumb');
 	    $parentLink = get_permalink($post->post_parent);
 	    $parentTitle = get_the_title($post->post_parent);
@@ -742,8 +742,8 @@ if (!function_exists('better_breadcrumbs')) {
 	    $pageLink = get_permalink($post);
 	    $childBreadcrumb = $startLink.$pageLink.$endLink.$pageTitle.$closeLink;
 
-		  if ($parentBreadcrumb !="" && $hideParent != 1) {echo "<span>".$parentBreadcrumb."</span>";}
-		  if ($childBreadcrumb != "") {echo "<span>".$pageTitle."</span>";}
+		  if ( $parentBreadcrumb !="" && $hideParent != 1 ) {echo "<span>".$parentBreadcrumb."</span>";}
+		  if ( $childBreadcrumb != "" ) {echo "<span>".$pageTitle."</span>";}
 		}
 	}
 
@@ -752,7 +752,7 @@ if (!function_exists('better_breadcrumbs')) {
 
 // Check for performance issues
 function no_post_limit( $query ) {
-	if ( is_home() && !is_child_theme()) {
+	if ( is_home() && !is_child_theme() ) {
 	// No post limit on homepage
 	$query->set( 'posts_per_page', -1 );
 	return;
@@ -761,10 +761,10 @@ function no_post_limit( $query ) {
 add_action( 'pre_get_posts', 'no_post_limit', 1 );
 
 // Prevent Wordpress from "guessing" redirects instead of showing a 404 page
-if (!function_exists('stop_404_guessing')) {
+if ( !function_exists('stop_404_guessing') ) {
 	add_filter('redirect_canonical', 'stop_404_guessing');
-	function stop_404_guessing($url) {
-		if (is_404()) {
+	function stop_404_guessing( $url ) {
+		if ( is_404() ) {
 			return false;
 		}
 		return $url;
@@ -775,7 +775,7 @@ if (!function_exists('stop_404_guessing')) {
 // First make all metaboxes have 'normal' context
 // If you know the ids of the metaboxes, you could add them here and skip the next function altogether
 add_filter('get_user_option_meta-box-order_post', 'one_column_for_all', 10, 1);
-function one_column_for_all($option) {
+function one_column_for_all( $option ) {
 	$result['normal'] = 'submitdev, postexcerpt,formatdiv,trackbacksdiv,tagsdiv,post_tag,categorydiv,postimagediv,postcustom,commentstatusdiv,slugdiv,authordiv';
 	$result['side'] = '';
 	$result['advanced'] = '';
@@ -785,7 +785,7 @@ function one_column_for_all($option) {
 // Then we add 'submitdiv' on the bottom, by creating this filter with a low priority
 // It feels a bit like overkill, because it assumes other plug-ins might be using the same filter, but still...
 add_filter('get_user_option_meta-box-order_post','submitdiv_at_top', 1, 1);
-function submitdiv_at_top($result){
+function submitdiv_at_top( $result ) {
 	$result['normal'] .= 'submitdiv';
 	return $result;
 }
@@ -826,7 +826,7 @@ if ( function_exists( 'get_fields' ) ) {
 
 // Allows SVGs to be uploaded through media
 
-function cc_mime_types( $mimes ){
+function cc_mime_types( $mimes ) {
 $mimes['svg'] = 'image/svg+xml';
 return $mimes;
 }

--- a/functions.php
+++ b/functions.php
@@ -21,9 +21,9 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 /* Globals */
- 
+
 $gStudy24Url = "/study/24x7/";
 
 // use newsBlog for live site
@@ -33,13 +33,13 @@ $gStudy24Url = "/study/24x7/";
 //$siteRoot = "/var/www/vhosts/seangw.com/mitlibraries";
 $siteRoot = $_SERVER['DOCUMENT_ROOT'];
 foreach(glob($siteRoot."/wp-content/themes/libraries/lib/*.php") as $file) require_once($file);
- 
+
 /**
  * Sets up the content width value based on the theme's design and stylesheet.
  */
 if ( ! isset( $content_width ) )
 	$content_width = 625;
-	
+
 /**
  * Sets up theme defaults and registers the various WordPress features that
  * Twenty Twelve supports.
@@ -113,13 +113,12 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_style('libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array('twentytwelve-style'), '2.2.0');
 
-
 	wp_enqueue_style('libraries-global');
 
 	wp_register_style('get-it', get_template_directory_uri() . '/css/build/minified/get-it.min.css', array('libraries-global'), '1.0');
 
 	wp_register_style('hours', get_template_directory_uri() . '/css/build/minified/hours.min.css', array('libraries-global'), '1.0');
-	
+
 		wp_register_style( 'bootstrapCSS', get_stylesheet_directory_uri() . '/css/bootstrap.css', 'false', '', false);
 
 wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.smartmenus.bootstrap.js', false, false );
@@ -128,12 +127,12 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
 	 */
 	wp_enqueue_style( 'twentytwelve-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentytwelve-style' ), '20121010' );
 	$wp_styles->add_data( 'twentytwelve-ie', 'conditional', 'lt IE 9' );
-	
+
 	/*  Register JS */
 
 	// Deregister WP Core jQuery, load Google's
   wp_deregister_script('jquery');
-  
+
   wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', array(), '1.11.1', false);
 
   wp_register_script( 'bootstrap-js', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
@@ -141,9 +140,9 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
   wp_register_script( 'jquery.smartmenus', '/js/bootstrap-js/jquery.smartmenus.js', array('jquery'), true); // all the bootstrap javascript goodness
 
   wp_register_script( 'bootstrap-min', '/js/bootstrap-js/bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
-   
+
    wp_register_script( 'jquery.smartmenus.bootstrap.min', '/js/bootstrap-js/jquery.smartmenus.bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
-    			
+
 	wp_register_script('modernizr', get_template_directory_uri() . '/js/modernizr.js', array(), '2.8.1', false);
 
 	wp_register_script('homeJS', get_template_directory_uri() . '/js/build/home.min.js', array('jquery', 'modernizr'), '2.2.0', true);
@@ -165,13 +164,13 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
 	wp_register_script('moment',     '//' . $_SERVER["SERVER_NAME"] . '/app/libhours/js/vendor/moment.js', false, false, true);
 
 	wp_register_script('tabletop',   '//' . $_SERVER["SERVER_NAME"] . '/app/libhours/js/vendor/tabletop.js', false, false, true);
-	
+
 	wp_register_script('underscore', '//' . $_SERVER["SERVER_NAME"] . '/app/libhours/js/vendor/underscore.js', false, false, true);
-	
+
 	wp_register_script('lib-hours',  '//' . $_SERVER["SERVER_NAME"] . '/app/libhours/js/libhours.js', array('moment','tabletop','underscore'), false, true);
 
 	/* All-site JS */
-	
+
 	wp_enqueue_script('modernizr');
 
 	wp_enqueue_script('lib-hours');
@@ -208,20 +207,20 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
 	if (is_page('getit')) {
 		wp_enqueue_style('get-it');
 	}
-	
+
 	if (is_page_template('nav-maine')) {
 		wp_enqueue_style('jquery.smartmenus.bootstrap');
 		wp_enqueue_script('bootstrap.min');
 		wp_enqueue_script('jquery.smartmenus.bootstrap.min');
 		wp_enqueue_script('jquery.smartmenus');
 	}
-		
+
 	if (in_category('has-menu')) {
 		wp_enqueue_style('libraries-global');
 		wp_enqueue_style('bootstrapCSS');
 		wp_enqueue_script('bootstrap-js');
 	}
-	
+
 }
 
 add_action( 'wp_enqueue_scripts', 'twentytwelve_scripts_styles' );
@@ -488,11 +487,11 @@ function twentytwelve_body_class( $classes ) {
 	if (is_child_theme()) {
 		$classes[] = 'childTheme';
 	}
-	
+
 	if(is_child_page()) {
 		$classes[] = 'childPage';
 	}
-	
+
 	if (is_page_template('page-selfTitle.php')) {
 		$classes[] = 'boxSizingOn';
 	}
@@ -554,22 +553,21 @@ add_action( 'customize_preview_init', 'twentytwelve_customize_preview_js' );
 /** Unique for theme **/
 
 function getParent($id) {
-	
+
 }
 function getRoot($post) {
 	$ar = get_post_ancestors($post);
-	
+
 	$is_section = get_post_meta($post->ID, "is_section", 1);
-	
-	
+
 	for($i=0;$i<count($ar);$i++) {
 		$pid = $ar[$i];
 		$is_section = get_post_meta($pid, "is_section", 1);
 		if ($is_section == 1) {
 			return $pid;
-		}	
+		}
 	}
-	
+
 	$max = count($ar)-1;
 
 	if ($max == -1) {
@@ -599,65 +597,65 @@ function the_breadcrumb() {
 	}
 }
 
-function wsf_make_link ( $url, $anchortext, $title=null, $nofollow=false ) {  
-   if ( $title == null ) $title=$anchortext;  
-   $nofollow==true ? $rel=' rel="nofollow"' : $rel = '';   
-   
-   $link = sprintf( '<a href="%s" title="%s" %s="">%s</a>', $url, $title, $rel, $anchortext );  
-   return $link;   
-}  
+function wsf_make_link ( $url, $anchortext, $title=null, $nofollow=false ) {
+   if ( $title == null ) $title=$anchortext;
+   $nofollow==true ? $rel=' rel="nofollow"' : $rel = '';
+
+   $link = sprintf( '<a href="%s" title="%s" %s="">%s</a>', $url, $title, $rel, $anchortext );
+   return $link;
+}
 
 function showBreadTitle() {
-   // Wordpess function that echoes your post title.  
+   // Wordpess function that echoes your post title.
 	$custom_title = get_post_meta($post->ID, "breadcrumb_override", 1);
 	$custom_title = $custom_title[0];
-   //$custom_title = get_field("breadcrumb_override");   
-   
+   //$custom_title = get_field("breadcrumb_override");
+
    if ($custom_title != "") {
 	 echo $custom_title;
    } else {
-     the_title();  
-   }	
+     the_title();
+   }
 }
 
-function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {  
-       
-    global $post;  
-  
-   // Do not show breadcrumbs on home or front pages.  
-   // So we will just return quickly  
-   if((is_home() || is_front_page()) && (!$front_page))  
-      return;  
-  
-    // Create a constant for the separator, with space padding.  
-    $SEP = ' ' . $sep . ' ';  
-  
-  echo '<div class="breadcrumbs">';  
-    
-  echo wsf_make_link( get_bloginfo('url'), 'Home', get_bloginfo('name'), true ) . $SEP;  
-       
-  if(is_single()) {  
-    the_category(', '); echo $SEP;   
-    }  
-    elseif(is_page()) {  
-            $parent_id = $post->post_parent;  
-            $parents = array();  
-            while($parent_id) {  
-                $page = get_page($parent_id);  
-            $parents[]  = wsf_make_link( get_permalink($page->ID), get_the_title($page->ID) ) . $SEP;  
-                $parent_id  = $page->post_parent;  
-            }  
-            $parents = array_reverse($parents);  
-            foreach($parents as $parent) {  
-                echo $parent;  
-            }  
-   }  
-   // Wordpess function that echoes your post title.  
+function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
+
+    global $post;
+
+   // Do not show breadcrumbs on home or front pages.
+   // So we will just return quickly
+   if((is_home() || is_front_page()) && (!$front_page))
+      return;
+
+    // Create a constant for the separator, with space padding.
+    $SEP = ' ' . $sep . ' ';
+
+  echo '<div class="breadcrumbs">';
+
+  echo wsf_make_link( get_bloginfo('url'), 'Home', get_bloginfo('name'), true ) . $SEP;
+
+  if(is_single()) {
+    the_category(', '); echo $SEP;
+    }
+    elseif(is_page()) {
+            $parent_id = $post->post_parent;
+            $parents = array();
+            while($parent_id) {
+                $page = get_page($parent_id);
+            $parents[]  = wsf_make_link( get_permalink($page->ID), get_the_title($page->ID) ) . $SEP;
+                $parent_id  = $page->post_parent;
+            }
+            $parents = array_reverse($parents);
+            foreach($parents as $parent) {
+                echo $parent;
+            }
+   }
+   // Wordpess function that echoes your post title.
    $custom_title = get_field("breadcrumb_override");
-   
+
    showBreadTitle();
-     echo '</div>';  
-} 
+     echo '</div>';
+}
 
 function cf($name) {
 	return get_post_meta( get_the_ID(), $name, true);
@@ -692,17 +690,17 @@ function remove_template( $files_to_delete = array() ){
 
 function menuWithParent($menu, $par) {
 	$menu_items = wp_get_nav_menu_items($menu);
-	
+
 	$arOut = array();
-	
+
 	foreach($menu_items as $key => $item) {
 		if ($item->menu_item_parent == $par) {
 			array_push($arOut, $item);
 		}
 	}
-	
+
 	return $arOut;
-	
+
 }
 
 function getExpert($expert) {
@@ -710,13 +708,11 @@ function getExpert($expert) {
 		'post_type' => 'expert',
 		'p' => $expert
 	);
-	
-	
-	
+
 	$qExpert = new WP_Query( $args );
-	
+
 	print_r($qExpert);
-	
+
 }
 
 if (!function_exists('better_breadcrumbs')) {
@@ -797,8 +793,8 @@ function submitdiv_at_top($result){
 add_filter( 'get_user_option_meta-box-order_{page}', 'metabox_order' );
 function metabox_order( $order ) {
     return array(
-        'normal' => join( 
-            ",", 
+        'normal' => join(
+            ",",
             array(       // vvv  Arrange here as you desire
                 'submitdiv',
                 'pageparentdiv',
@@ -834,4 +830,4 @@ function cc_mime_types( $mimes ){
 $mimes['svg'] = 'image/svg+xml';
 return $mimes;
 }
-add_filter( 'upload_mimes', 'cc_mime_types' ); 
+add_filter( 'upload_mimes', 'cc_mime_types' );

--- a/functions.php
+++ b/functions.php
@@ -27,8 +27,8 @@
 $gStudy24Url = "/study/24x7/";
 
 // use newsBlog for live site
- $newsBlog = 7;
- $mainSite = 1;
+	$newsBlog = 7;
+	$mainSite = 1;
 
 //$siteRoot = "/var/www/vhosts/seangw.com/mitlibraries";
 $siteRoot = $_SERVER['DOCUMENT_ROOT'];
@@ -131,17 +131,17 @@ wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.sma
 	/*  Register JS */
 
 	// Deregister WP Core jQuery, load Google's
-  wp_deregister_script('jquery');
+	wp_deregister_script('jquery');
 
-  wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', array(), '1.11.1', false);
+	wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', array(), '1.11.1', false);
 
-  wp_register_script( 'bootstrap-js', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
+	wp_register_script( 'bootstrap-js', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
 
-  wp_register_script( 'jquery.smartmenus', '/js/bootstrap-js/jquery.smartmenus.js', array('jquery'), true); // all the bootstrap javascript goodness
+	wp_register_script( 'jquery.smartmenus', '/js/bootstrap-js/jquery.smartmenus.js', array('jquery'), true); // all the bootstrap javascript goodness
 
-  wp_register_script( 'bootstrap-min', '/js/bootstrap-js/bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
+	wp_register_script( 'bootstrap-min', '/js/bootstrap-js/bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
 
-   wp_register_script( 'jquery.smartmenus.bootstrap.min', '/js/bootstrap-js/jquery.smartmenus.bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
+	wp_register_script( 'jquery.smartmenus.bootstrap.min', '/js/bootstrap-js/jquery.smartmenus.bootstrap.min.js', array('jquery'), true); // all the bootstrap javascript goodness
 
 	wp_register_script('modernizr', get_template_directory_uri() . '/js/modernizr.js', array(), '2.8.1', false);
 
@@ -446,9 +446,9 @@ if (!function_exists('is_child_page')) {
 	global $post;     // if outside the loop
 
 	if ( is_page() && $post->post_parent ) {
-    return $post->post_parent;
+	return $post->post_parent;
 	} else {
-    return false;
+	return false;
 	}
 }
 }
@@ -598,63 +598,63 @@ function the_breadcrumb() {
 }
 
 function wsf_make_link ( $url, $anchortext, $title=null, $nofollow=false ) {
-   if ( $title == null ) $title=$anchortext;
-   $nofollow==true ? $rel=' rel="nofollow"' : $rel = '';
+	if ( $title == null ) $title=$anchortext;
+	$nofollow==true ? $rel=' rel="nofollow"' : $rel = '';
 
-   $link = sprintf( '<a href="%s" title="%s" %s="">%s</a>', $url, $title, $rel, $anchortext );
-   return $link;
+	$link = sprintf( '<a href="%s" title="%s" %s="">%s</a>', $url, $title, $rel, $anchortext );
+	return $link;
 }
 
 function showBreadTitle() {
-   // Wordpess function that echoes your post title.
+	// Wordpess function that echoes your post title.
 	$custom_title = get_post_meta($post->ID, "breadcrumb_override", 1);
 	$custom_title = $custom_title[0];
-   //$custom_title = get_field("breadcrumb_override");
+	//$custom_title = get_field("breadcrumb_override");
 
-   if ($custom_title != "") {
+	if ($custom_title != "") {
 	 echo $custom_title;
-   } else {
-     the_title();
-   }
+	} else {
+	 the_title();
+	}
 }
 
 function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
 
-    global $post;
+	global $post;
 
-   // Do not show breadcrumbs on home or front pages.
-   // So we will just return quickly
-   if((is_home() || is_front_page()) && (!$front_page))
-      return;
+	// Do not show breadcrumbs on home or front pages.
+	// So we will just return quickly
+	if((is_home() || is_front_page()) && (!$front_page))
+	  return;
 
-    // Create a constant for the separator, with space padding.
-    $SEP = ' ' . $sep . ' ';
+	// Create a constant for the separator, with space padding.
+	$SEP = ' ' . $sep . ' ';
 
-  echo '<div class="breadcrumbs">';
+	echo '<div class="breadcrumbs">';
 
-  echo wsf_make_link( get_bloginfo('url'), 'Home', get_bloginfo('name'), true ) . $SEP;
+	echo wsf_make_link( get_bloginfo('url'), 'Home', get_bloginfo('name'), true ) . $SEP;
 
-  if(is_single()) {
-    the_category(', '); echo $SEP;
-    }
-    elseif(is_page()) {
-            $parent_id = $post->post_parent;
-            $parents = array();
-            while($parent_id) {
-                $page = get_page($parent_id);
-            $parents[]  = wsf_make_link( get_permalink($page->ID), get_the_title($page->ID) ) . $SEP;
-                $parent_id  = $page->post_parent;
-            }
-            $parents = array_reverse($parents);
-            foreach($parents as $parent) {
-                echo $parent;
-            }
-   }
-   // Wordpess function that echoes your post title.
-   $custom_title = get_field("breadcrumb_override");
+	if(is_single()) {
+	the_category(', '); echo $SEP;
+	}
+	elseif(is_page()) {
+			$parent_id = $post->post_parent;
+			$parents = array();
+			while($parent_id) {
+				$page = get_page($parent_id);
+			$parents[]  = wsf_make_link( get_permalink($page->ID), get_the_title($page->ID) ) . $SEP;
+				$parent_id  = $page->post_parent;
+			}
+			$parents = array_reverse($parents);
+			foreach($parents as $parent) {
+				echo $parent;
+			}
+	}
+	// Wordpess function that echoes your post title.
+	$custom_title = get_field("breadcrumb_override");
 
-   showBreadTitle();
-     echo '</div>';
+	showBreadTitle();
+	 echo '</div>';
 }
 
 function cf($name) {
@@ -662,30 +662,30 @@ function cf($name) {
 }
 
 function remove_template( $files_to_delete = array() ){
-    global $wp_themes;
+	global $wp_themes;
 
-    // As convenience, allow a single value to be used as a scalar without wrapping it in a useless array()
-    if ( is_scalar( $files_to_delete ) ) $files_to_delete = array( $files_to_delete );
+	// As convenience, allow a single value to be used as a scalar without wrapping it in a useless array()
+	if ( is_scalar( $files_to_delete ) ) $files_to_delete = array( $files_to_delete );
 
-    // remove TLA if it was provided
-    $files_to_delete = preg_replace( "/\.[^.]+$/", '', $files_to_delete );
+	// remove TLA if it was provided
+	$files_to_delete = preg_replace( "/\.[^.]+$/", '', $files_to_delete );
 
-    // Populate the global $wp_themes array
-    get_themes();
+	// Populate the global $wp_themes array
+	get_themes();
 
-    $current_theme_name = get_current_theme();
+	$current_theme_name = get_current_theme();
 
-    // Note that we're taking a reference to $wp_themes so we can modify it in-place
-    $template_files = &$wp_themes[$current_theme_name]['Template Files'];
+	// Note that we're taking a reference to $wp_themes so we can modify it in-place
+	$template_files = &$wp_themes[$current_theme_name]['Template Files'];
 
-    foreach ( $template_files as $file_path ){
-        foreach( $files_to_delete as $file_name ){
-            if ( preg_match( '/\/'.$file_name.'\.[^.]+$/', $file_path ) ){
-                $key = array_search( $file_path, $template_files );
-                if ( $key ) unset ( $template_files[$key] );
-            }
-        }
-    }
+	foreach ( $template_files as $file_path ){
+		foreach( $files_to_delete as $file_name ){
+			if ( preg_match( '/\/'.$file_name.'\.[^.]+$/', $file_path ) ){
+				$key = array_search( $file_path, $template_files );
+				if ( $key ) unset ( $template_files[$key] );
+			}
+		}
+	}
 }
 
 function menuWithParent($menu, $par) {
@@ -752,11 +752,11 @@ if (!function_exists('better_breadcrumbs')) {
 
 // Check for performance issues
 function no_post_limit( $query ) {
-  if ( is_home() && !is_child_theme()) {
-    // No post limit on homepage
-    $query->set( 'posts_per_page', -1 );
-    return;
-  }
+	if ( is_home() && !is_child_theme()) {
+	// No post limit on homepage
+	$query->set( 'posts_per_page', -1 );
+	return;
+	}
 }
 add_action( 'pre_get_posts', 'no_post_limit', 1 );
 
@@ -776,36 +776,36 @@ if (!function_exists('stop_404_guessing')) {
 // If you know the ids of the metaboxes, you could add them here and skip the next function altogether
 add_filter('get_user_option_meta-box-order_post', 'one_column_for_all', 10, 1);
 function one_column_for_all($option) {
-    $result['normal'] = 'submitdev, postexcerpt,formatdiv,trackbacksdiv,tagsdiv,post_tag,categorydiv,postimagediv,postcustom,commentstatusdiv,slugdiv,authordiv';
-    $result['side'] = '';
-    $result['advanced'] = '';
-    return $result;
+	$result['normal'] = 'submitdev, postexcerpt,formatdiv,trackbacksdiv,tagsdiv,post_tag,categorydiv,postimagediv,postcustom,commentstatusdiv,slugdiv,authordiv';
+	$result['side'] = '';
+	$result['advanced'] = '';
+	return $result;
 }
 
 // Then we add 'submitdiv' on the bottom, by creating this filter with a low priority
 // It feels a bit like overkill, because it assumes other plug-ins might be using the same filter, but still...
 add_filter('get_user_option_meta-box-order_post','submitdiv_at_top', 1, 1);
 function submitdiv_at_top($result){
-    $result['normal'] .= 'submitdiv';
-    return $result;
+	$result['normal'] .= 'submitdiv';
+	return $result;
 }
 
 add_filter( 'get_user_option_meta-box-order_{page}', 'metabox_order' );
 function metabox_order( $order ) {
-    return array(
-        'normal' => join(
-            ",",
-            array(       // vvv  Arrange here as you desire
-                'submitdiv',
-                'pageparentdiv',
-                'dmm-meta-box',
-                'prfx_meta',
-                'categorydiv',
-                'tagsdiv-post_tag',
-                'postimagediv'
-            )
-        ),
-    );
+	return array(
+		'normal' => join(
+			",",
+			array(       // vvv  Arrange here as you desire
+				'submitdiv',
+				'pageparentdiv',
+				'dmm-meta-box',
+				'prfx_meta',
+				'categorydiv',
+				'tagsdiv-post_tag',
+				'postimagediv'
+			)
+		),
+	);
 }
 
 /**

--- a/header-home.php
+++ b/header-home.php
@@ -60,7 +60,7 @@
 
 		</header>
 
-		<?php 
+		<?php
 
 			$pageRoot = getRoot($post);
 			$section = get_post($pageRoot);

--- a/header.php
+++ b/header.php
@@ -57,7 +57,7 @@
 
 		</header>
 
-		<?php 
+		<?php
 
 			$pageRoot = getRoot($post);
 			$section = get_post($pageRoot);

--- a/inc/alert.php
+++ b/inc/alert.php
@@ -5,10 +5,10 @@
 	$alertText = trim(get_post_meta($frontpage_id, 'alert_text', true));
 	$alertLink = trim(get_post_meta($frontpage_id, 'alert_link', true));
 
-	if ($showAlert == 1 && $alertText != "") {
+	if ( $showAlert == 1 && $alertText != "" ) {
 
-		if(is_front_page()) {
-			if ($alertLink != '') {
+		if ( is_front_page() ) {
+			if ( $alertLink != '' ) {
 				echo '<h1 class="alert"><a href="'.$alertLink.'">'.$alertText.'</a></h1>';
 				return;
 			}
@@ -18,8 +18,8 @@
 			}
 		}
 
-		if(is_page('hours')) {
-			if ($alertLink != '') {
+		if ( is_page('hours') ) {
+			if ( $alertLink != '' ) {
 				echo '<div class="libraryAlert"><span><a href="'.$alertLink.'">'.$alertText.'</a></span></div>';
 				return;
 			}
@@ -30,7 +30,7 @@
 		}
 
 
-		if ($alertLink != '') {
+		if ( $alertLink != '' ) {
 			echo '<div class="libraryAlert"><a href="'.$alertLink.'">'.$alertText.'</a></div>';
 			return;
 		}
@@ -38,8 +38,7 @@
 			echo '<div class="libraryAlert">'.$alertText.'</div>';
 			return;
 		}
-
-	}
+}
 
 	else {
 		return;

--- a/inc/alert.php
+++ b/inc/alert.php
@@ -29,7 +29,7 @@
 			}
 		}
 
-		
+
 		if ($alertLink != '') {
 			echo '<div class="libraryAlert"><a href="'.$alertLink.'">'.$alertText.'</a></div>';
 			return;
@@ -38,7 +38,7 @@
 			echo '<div class="libraryAlert">'.$alertText.'</div>';
 			return;
 		}
-		
+
 	}
 
 	else {

--- a/inc/content-noTitle.php
+++ b/inc/content-noTitle.php
@@ -11,7 +11,7 @@ global $isRoot;
 
 <div id="mainContent" class="mainContent">
 
-	<?php if (has_post_thumbnail()): ?>
+	<?php if ( has_post_thumbnail() ) : ?>
 
 		<div class="featuredImage">
 			<?php echo the_post_thumbnail(700, 300); ?>

--- a/inc/content-root.php
+++ b/inc/content-root.php
@@ -14,9 +14,9 @@ $isRoot = $section->ID == $post->ID;
 ?>
 
 <div class="title-page">
-				<?php if ($isRoot): ?>
+				<?php if ( $isRoot ) : ?>
 				<h1><?php echo $section->post_title; ?></h1>
-				<?php else: ?>
+				<?php else : ?>
 				<a class="title-page" href="<?php echo get_permalink($section->ID) ?>"><?php echo $section->post_title; ?></a>
 				<?php endif; ?>
 			</div>

--- a/inc/content-root.php
+++ b/inc/content-root.php
@@ -6,7 +6,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;

--- a/inc/content-secmenu.php
+++ b/inc/content-secmenu.php
@@ -27,20 +27,20 @@ global $isRoot;
     </div>
 
         <?php
-            wp_nav_menu( array(
-                'menu'              => 'Secondary Menu',
-                'theme_location'    => 'secondary',
-                'depth'             => 2,
-                'container_class'   => 'collapse navbar-collapse nav-menu',
+			wp_nav_menu( array(
+				'menu'              => 'Secondary Menu',
+				'theme_location'    => 'secondary',
+				'depth'             => 2,
+				'container_class'   => 'collapse navbar-collapse nav-menu',
 				'container_id'      => 'bs-example-navbar-collapse-1',
-                'menu_class'        => 'nav navbar-nav nav-second',
-                'fallback_cb'       => false,
-                'walker'            => new navwalker())
-            );
+				'menu_class'        => 'nav navbar-nav nav-second',
+				'fallback_cb'       => false,
+				'walker'            => new navwalker())
+			);
 
 
 
-        ?>
+		?>
 
     </div>
 </nav>

--- a/inc/content-secmenu.php
+++ b/inc/content-secmenu.php
@@ -6,7 +6,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 global $isRoot;
 
 ?>
@@ -37,8 +37,8 @@ global $isRoot;
                 'fallback_cb'       => false,
                 'walker'            => new navwalker())
             );
-            
-                       
+
+
 
         ?>
 

--- a/inc/homepage-news.php
+++ b/inc/homepage-news.php
@@ -18,11 +18,11 @@
 		$arNews = array();
 
 
-		for($i=1;$i<=$numNews;$i++) {
+		for ( $i=1;$i<=$numNews;$i++ ) {
 			$nTitle = get_field("news_".$i);
 			$nUrl = get_field("news_".$i."_url");
 
-			if ($nTitle != "" && $nUrl != "") {
+			if ( $nTitle != "" && $nUrl != "" ) {
 				$arNews[] = array(
 					"title" => $nTitle,
 					"url" => $nUrl
@@ -33,23 +33,23 @@
 
 	<div class="blockimage">
 
-		<?php if ($newsVideo != ""): ?>
+		<?php if ( $newsVideo != "" ) : ?>
 			<div class="homepageVideo"><?php echo $newsVideo; ?></div>
-		<?php else: ?>
+		<?php else : ?>
 
-			<?php if ($newsPhoto != ""): ?>
+			<?php if ( $newsPhoto != "" ) : ?>
 
-			<?php if ($newsUrl != ""): ?>
+			<?php if ( $newsUrl != "" ) : ?>
 				<a href="<?php echo $newsUrl; ?>">
 			<?php endif; ?>
 
 			<img src="<?php echo $newsPhoto; ?>"  alt="<?php echo $newsTitle; ?>">
 
-			<?php if ($newsUrl != ""): ?>
+			<?php if ( $newsUrl != "" ) : ?>
 					</a>
 			<?php endif; ?>
 
-			<?php else: ?>
+			<?php else : ?>
 			<!-- default news photo -->
 			<a href="/news/finals-survival-libraries/10129/"><img src="/images/features/cookies-with-canines.jpg"  alt="students petting a dog"</a>
 
@@ -59,14 +59,14 @@
 
 	</div> <!-- end blockimage -->
 	
-	<?php if ($newsVideoURL != ""): ?>
+	<?php if ( $newsVideoURL != "" ) : ?>
 		<p><a href="<?php echo $newsVideoURL; ?>"><?php echo $newsVideoTitle; ?></a></p>
-	<?php else: ?>
+	<?php else : ?>
 
-		<?php if ($newsTitle != "" && $newsUrl != ""): ?>
+		<?php if ( $newsTitle != "" && $newsUrl != "" ) : ?>
 	
 			<p><a href="<?php echo $newsUrl; ?>"><?php echo $newsTitle; ?></a></p>
-			<?php else: ?>
+			<?php else : ?>
 			<!-- default news link -->
 			<p><a href="/news/finals-survival-libraries/10129/">Finals week survival kit from the MIT Libraries</a></p>
 		
@@ -77,7 +77,7 @@
 	<ul class="linklist">
 		<!-- custom links -->
 		<?php
-			foreach($arNews as $news):
+			foreach ( $arNews as $news ) :
 				$nTitle = $news["title"];
 				$nUrl = $news["url"];
 
@@ -88,7 +88,7 @@
 
 		<!-- Auto links -->
 		<?php
-			if ($newsFeedCount > 0):
+			if ( $newsFeedCount > 0 ) :
 				if ($newsBlog) switch_to_blog($newsBlog);
 					$args = array(
 					'post_type' => 'post',
@@ -97,7 +97,7 @@
 
 			$news = new WP_Query( $args );
 
-			while($news->have_posts()):
+			while ( $news->have_posts() ) :
 				$news->the_post();
 		?>
 

--- a/inc/homepage-news.php
+++ b/inc/homepage-news.php
@@ -18,7 +18,7 @@
 		$arNews = array();
 
 
-		for ( $i=1;$i<=$numNews;$i++ ) {
+		for ( $i = 1;$i <= $numNews;$i++ ) {
 			$nTitle = get_field("news_".$i);
 			$nUrl = get_field("news_".$i."_url");
 

--- a/inc/homepage-news.php
+++ b/inc/homepage-news.php
@@ -10,18 +10,18 @@
 		$newsVideoURL = get_field("news_video_url");
 		$newsPhoto = get_field("news_photo");
 		$newsUrl = get_field("news_photo_url");
-		
+
 		$newsFeedCount = get_field("news_feed_number");
-		
+
 		$numNews = 3;
-		
+
 		$arNews = array();
 
-		
+
 		for($i=1;$i<=$numNews;$i++) {
 			$nTitle = get_field("news_".$i);
 			$nUrl = get_field("news_".$i."_url");
-			
+
 			if ($nTitle != "" && $nUrl != "") {
 				$arNews[] = array(
 					"title" => $nTitle,
@@ -80,9 +80,9 @@
 			foreach($arNews as $news):
 				$nTitle = $news["title"];
 				$nUrl = $news["url"];
-				
+
 				echo "<li><a href='$nUrl'>$nTitle</a></li>";
-			
+
 			endforeach;
 		?>
 
@@ -94,9 +94,9 @@
 					'post_type' => 'post',
 					'posts_per_page' => $newsFeedCount
 					);
-			
+
 			$news = new WP_Query( $args );
-			
+
 			while($news->have_posts()):
 				$news->the_post();
 		?>

--- a/inc/location-info.php
+++ b/inc/location-info.php
@@ -13,7 +13,7 @@
 
 	$locationsQuery = new WP_Query($args);
 
-	while ($locationsQuery->have_posts()) {
+	while ( $locationsQuery->have_posts() ) {
 			$locationsQuery->the_post();
 			echo '<div class="location"><h3>' . get_the_title() . '</h3></div>';
 	}

--- a/inc/self-title.php
+++ b/inc/self-title.php
@@ -10,7 +10,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -19,47 +19,46 @@ $expireShort = 60*5; // 5 minutes
 date_default_timezone_set("America/New_York");
 
 function getHours() {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
-	
+	global $resetCache, $expireLong, $expireShort, $locationReset;
+
 	$key = "getHours";
-	$expire = $expireShort; 
+	$expire = $expireShort;
 	$data = get_transient( $key );
-	
+
 	if ($data === false || $resetCache) {
-		
+
 		// gets the entire hours object;
 		global $post;
-		
+
 		$gHours = array();
-		
+
 		$args = array(
 			'post_type' => 'hours',
 			'posts_per_page' => -1,
 			'post_parent' => 0,
 		);
-		
+
 		$hours = new WP_Query( $args );
 		while($hours->have_posts()):
-			
+
 			$hours->the_post();
 			$id = get_the_ID();
-			
-			
+
 			$name = get_the_title();
-			
+
 			$description = get_field("description");
 			$description = str_replace(":00", "", $description);
-			
+
 			$start = get_field("start");
 			$end = get_field("end");
-			
+
 			$spanning = get_field("show_spanning");
-			
+
 			$term = get_field("is_term");
-			
+
 			$location = get_field("associated_location");
 			$locationId = $location->ID;
-			
+
 			$arHours[$locationId] = array(
 				'id' => $id,
 				'name' => $name,
@@ -71,48 +70,47 @@ function getHours() {
 				'terms' => getHoursChildren($id)
 			);
 		endwhile;
-		
+
 		wp_reset_query();
-		
+
 		$data = $arHours;
 		set_transient( $key, $data, $expire );
 	}
-		
+
 	return $data;
 }
 
 function getHoursChildren($parent) {
 	$arHours = array();
-	
+
 	$args = array(
 		'post_type' => 'hours',
 		'orderby' => 'date',
-		'order' => 'ASC',		
+		'order' => 'ASC',
 		'posts_per_page' => -1,
 		'post_parent' => $parent
 	);
-	
-	
+
 	$hours = new WP_Query( $args );
 
 	while($hours->have_posts()):
-		
+
 		$hours->the_post();
 		$id = get_the_ID();
-		
+
 		$name = get_the_title();
-		
+
 		$description = get_field("description");
-		
+
 		$start = get_field("start");
 		$end = get_field("end");
-		
+
 		$spanning = get_field("show_spanning");
-		
+
 		$term = get_field("is_term");
-		
+
 		$arHours[$id] = array(
-			'id' => $id,		
+			'id' => $id,
 			'name' => $name,
 			'description' => $description,
 			'start' => $start,
@@ -123,18 +121,17 @@ function getHoursChildren($parent) {
 		);
 	endwhile;
 	wp_reset_query();
-	
-	
-	return $arHours;	
+
+	return $arHours;
 }
 
 function getHoursToday($locationId) {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
+	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$date = date("Y-m-d");
 	$key = "getHoursToday-$locationId-$date";
 	$expire = $expireShort;
 	$data = get_transient( $key );
-	
+
 	if ($data === false || $resetCache || $locationReset == $locationId) {
 		$data = getHoursDay($locationId, strtotime("Now"));
 		set_transient( $key, $data, $expire );
@@ -143,55 +140,53 @@ function getHoursToday($locationId) {
 }
 
 function hasHours($locationId, $curDay) {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
-	
+	global $resetCache, $expireLong, $expireShort, $locationReset;
+
 	$date = date("Y-m-d", strtotime($curDay));
 	$key = "hasHours-$locationId-$date";
 	$expire = $expireShort;
 	$data = get_transient( $key );
-	
+
 	if ($data === false || $resetCache || $locationReset == $locationId) {
 		$arHours = getHours();
-				
+
 		$dt = strtotime($curDay);
-		
+
 		$term = getTerm($arHours, $locationId, $dt);
-		
-	
+
 		if (count($term)==0) {
 			// no hours
 			$data = 0;
 		} else {
 			$data = 1;
 		}
-		set_transient( $key, $data, $expire );		
+		set_transient( $key, $data, $expire );
 	}
-	
+
 	return $data;
 }
 
 function getHoursDay($locationId, $dt) {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
+	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$key = "getHoursDay-$locationId-$dt";
 	$expire = $expireShort;
 	$data = get_transient( $key );
-	
+
 	if ($data === false || $resetCache || $locationReset == $locationId) {
 
 		$data = "";
 		$today = $dt;
 		//$today = strtotime("2013-04-20");
-		$dt = $today; 
-		
+		$dt = $today;
+
 		//echo "{{".date("Y-m-d", $dt)."}}";
-		
+
 		$arHours = getHours();
-			
+
 		$term = getTerm($arHours, $locationId, $dt);
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
-		
-		
+
 		if (count($term)==0) {
 			// no hours
 			$data = "TBA";
@@ -201,35 +196,33 @@ function getHoursDay($locationId, $dt) {
 		} else {
 			$data = $hour["description"];
 		}
-		
-		set_transient( $key, $data, $expire );		
+
+		set_transient( $key, $data, $expire );
 	}
 	return $data;
 }
 
 function getMobileHoursDay($locationId, $dt) {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
+	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$key = "getMobileHoursDay-$locationId-$dt";
 	$expire = $expireShort;
 	$data = get_transient( $key );
-	
-	if ($data === false || $resetCache || $locationReset == $locationId) {
 
+	if ($data === false || $resetCache || $locationReset == $locationId) {
 
 		$data = "";
 		$today = $dt;
 		//$today = strtotime("2013-04-20");
-		$dt = $today; 
-		
+		$dt = $today;
+
 		//echo "{{".date("Y-m-d", $dt)."}}";
-		
+
 		$arHours = getHours();
-			
+
 		$term = getTerm($arHours, $locationId, $dt);
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
-		
-		
+
 		if (count($term)==0) {
 			// no hours
 			$data = "TBA";
@@ -239,41 +232,41 @@ function getMobileHoursDay($locationId, $dt) {
 		} else {
 			$data = hourToMobile($hour["description"]);
 		}
-		
-		set_transient( $key, $data, $expire );		
+
+		set_transient( $key, $data, $expire );
 	}
 	return $data;
 }
 
 function getMessageDay($locationId, $dt) {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
+	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$key = "getMessageDay-$locationId-$dt";
 	$expire = $expireShort;
 	$data = get_transient( $key );
-	
+
 	if ($data === false || $resetCache || $locationReset == $locationId) {
 
 		//echo date("Y-m-d", $dt);
 		$data = "";
 		$today = $dt;
 		//$today = strtotime("2013-04-20");
-		$dt = $today; 
-		
+		$dt = $today;
+
 		$arHours = getHours();
-			
+
 		$term = getTerm($arHours, $locationId, $dt);
-		
+
 		//echo $locationId." - ".$dt."  ";
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
-				
+
 		$data = "";
-		
+
 		if ($hour["show_spanning"] == 1) {
 			$data = $hour;
 		}
-		
-		set_transient( $key, $data, $expire );		
+
+		set_transient( $key, $data, $expire );
 	}
 	return $data;
 }
@@ -281,26 +274,23 @@ function getMessageDay($locationId, $dt) {
 
 function getOpen($locationId) {
 	$today = strtotime("Now");
-	$dt = $today; 
-	
-	
+	$dt = $today;
 
 	$arHours = getHours();
-	
+
 	$term = getTerm($arHours, $locationId, $dt);
 	$hour = getTermHour($term, $dt);
-	
+
 	if (count($term)==0) {
 		// no hours
 		return false;
-	}	
-	
+	}
+
 	if (count($hour)==0) {
 		// no hours
 		return false;
-	}	
+	}
 
-	
 	return checkOpen($hour, $dt);
 }
 
@@ -308,7 +298,7 @@ function checkClosed($str) {
 	$str = strtolower($str);
 	if (
 		strpos($str, "closed") !== false ||
-		$str == "tba" || 
+		$str == "tba" ||
 		$str = ""
 		) {
 			return true;
@@ -334,78 +324,69 @@ function checkWeekday($str) {
 
 function checkOpen($hour, $dt) {
 	$hrs = strtolower($hour["description"]);
-	
+
 	if (
-		$hrs == "closed" || 
+		$hrs == "closed" ||
 		$hrs == "tba" ||
 		$hrs == ""
 		) {
 		return false;
 	}
-	
-	
-	
+
 	$arRange = explode("-", $hrs);
-	
+
 	$arRange[0] = filterText($arRange[0]);
-	$arRange[1] = filterText($arRange[1]);	
-	
+	$arRange[1] = filterText($arRange[1]);
+
 	$start = strtotime($arRange[0]);
-	
-	
-	
+
 	if ($arRange[1] == "midnight") {
 		$end = strtotime($arRange[1]." + 1 day");
 	} else {
 		$end = strtotime($arRange[1]);
 	}
-	
+
 	if ($start <= $dt && $dt <= $end) {
 		return true;
 	}
-	
+
 	return false;
 }
 
 function getHourHours($hour) {
 	$arOut = array();
-	
+
 	$hrs = strtolower($hour["description"]);
-	
+
 	if (
 		checkClosed($hrs)
 		) {
 		return false;
 	}
-	
-	
-	
+
 	$arRange = explode("-", $hrs);
-		
+
 	$arRange[0] = filterText($arRange[0]);
 	$arRange[1] = filterText($arRange[1]);
-	
+
 	$start = strtotime($arRange[0]);
-	
+
 	if ($arRange[1] == "midnight") {
 		$end = strtotime($arRange[1]." + 1 day");
 	} else {
 		$end = strtotime($arRange[1]);
 	}
-	
 
-	
 	$arOut[start] = date("H:i:s", $start);
 	$arOut[end] = date("H:i:s", $end);
-		
+
 	return $arOut;
-	
+
 }
 
 function dayLookup($str) {
 	$str = strtolower(date("l", strtotime($str)));
-	
-	
+
 	switch($str) {
 		case "monday":
 			return "M";
@@ -436,72 +417,68 @@ function toDays($str) {
 		// multi day
 		//echo $str;
 		$arRange = explode("-", $str);
-		
+
 		$start = $arRange[0];
 		$end = $arRange[1];
-		
+
 		$current = $start;
 		$currentShort = dayLookup($current);
-		
+
 		$startShort = dayLookup($start);
 		$endShort = dayLookup($end);
-		
+
 		$strOut = "";
-		
+
 		//echo $currentShort." vs ".$endShort;
 		while($currentShort != $endShort) {
 			$strOut .= $currentShort;
-			
+
 			$current = date("l", strtotime($current." + 1 day"));
 			$currentShort = dayLookup($current);
-			
-			
+
 		}
-		
+
 		$strOut .= $endShort;
-		
-		
-		
+
 		return $strOut;
 	} else {
 		// single day
-		
+
 		return dayLookup($str);
 	}
 	return $str;
 }
 
 function getTerm($obj, $location, $dt) {
-	global $resetCache, $expireLong, $expireShort, $locationReset; 
-	
+	global $resetCache, $expireLong, $expireShort, $locationReset;
+
 	$key = "getTerm-$location-$dt";
 	$expire = $expireLong;
 	$data = get_transient( $key );
-	
+
 	if ($data === false || $resetCache || $location == $locationReset) {
-		
+
 		$data = array();
-		
+
 		if ($obj[$location]) {
 			// location exists
 			$arTerms = $obj[$location]["terms"];
-			
+
 			//echo "[E: ".date("Y-m-d", $dt)." ]";
-			
+
 			foreach($arTerms as $termId => $term) {
 				$start = $term["start"];
 				$end = $term["end"];
-				
+
 				//echo "{ $start -> $dt -> $end }";
-				
+
 				$dt = strtotime(date("Y-m-d", $dt));
-				
+
 				$start = strtotime($start);
 				$end = strtotime($end);
-				
+
 				//echo "[ ".date("Y-m-d", $start)." ]";
-				
-				
+
 				if ($start <= $dt && $dt <= $end) {
 					//echo "FOUND";
 					$data = array(
@@ -509,48 +486,46 @@ function getTerm($obj, $location, $dt) {
 						"term"=>$term
 					);
 				}
-				
+
 			}
-			
+
 		} else {
 			//echo "TEST";
 		}
-		
+
 		//print_r($data);
-		
-		set_transient( $key, $data, $expire );		
+
+		set_transient( $key, $data, $expire );
 	}
-	
+
 	return $data;
 }
 
 function getTermHour($term, $dt) {
 	// check for special days
-	
+
 	if (count($term) == 0) {
 		return array();
 	}
-	
+
 	$dtWeek = date("l", $dt);
-	
+
 	$arHours = $term["term"]["hours"];
-	
+
 	// Special days
 	foreach($arHours as $hours) {
-
 
 		$start = $hours["start"];
 		if ($start != "") {
 
 			$end = $hours["end"];
-			
+
 			if ($end == "") $end = $start;
-			
+
 			$dt = strtotime(date("Ymd", $dt));
 
 			$start = strtotime($start);
-			$end = strtotime($end);		
-						
+			$end = strtotime($end);
 
 			if ($start <= $dt && $dt <= $end) {
 				return $hours;
@@ -558,7 +533,6 @@ function getTermHour($term, $dt) {
 		}
 	}
 
-	
 	// Day match
 	foreach($arHours as $hours) {
 		$start = $hours["start"];
@@ -570,7 +544,7 @@ function getTermHour($term, $dt) {
 			}
 		}
 	}
-	
+
 	// Day Span Match
 	foreach($arHours as $hours) {
 		$start = $hours["start"];
@@ -585,26 +559,25 @@ function getTermHour($term, $dt) {
 			}
 		}
 	}
-	
-	
+
 	return array();
 }
 
 function dateSpanFit($range, $dt) {
 	$arRange = explode("-", $range);
-	
+
 	$start = strtotime(trim($arRange[0]));
 	$end = strtotime(trim($arRange[1]));
-	
+
 	$startDay = date("N", $start);
 	$endDay = date("N", $end);
-	
+
 	$dtDay = date("N", strtotime($dt));
-	
+
 	if ($startDay <= $dtDay && $dtDay <= $endDay) {
 		return true;
 	}
-	
+
 	return false;
 }
 
@@ -615,8 +588,7 @@ function hourToMobile($str) {
 	$str = str_replace("am", "a", $str);
 	$str = str_replace("pm", "p", $str);
 	$str = str_replace("by appointment only", "appt only", $str);
-	
-	
+
 	return $str;
 }
 
@@ -629,8 +601,7 @@ function filterText($str) {
 	$str = str_replace("by appointment only", "", $str);
 	$str = str_replace("(", "", $str);
 	$str = str_replace(")", "", $str);
-	
-	
+
 	return $str;
 }
 
@@ -657,10 +628,10 @@ function import_hours() {
 		</p>
 	</form>
 <?php
-	if (isset($_POST["import_spreadsheet"])) {  
+	if (isset($_POST["import_spreadsheet"])) {
 		if (isset($_FILES["upload"]) && $_FILES["upload"]["name"] != "") {
 			handle_hours_upload();
-		} 
+		}
 		if (isset($_POST["tag_delete"]) && $_POST["tag_delete"] != "") {
 			clean_posts($_POST["tag_delete"]);
 			echo "Items removed with tag: ".$_POST["tag_delete"];
@@ -671,84 +642,75 @@ function import_hours() {
 
 function handle_hours_upload() {
 	echo "<p><hr></p>";
-	
+
 	$root = $_SERVER['DOCUMENT_ROOT'];
 
 	$siteRoot = $root;
 
 	require_once $siteRoot."/wp-content/themes/libraries/libs/PHPExcel-develop/Classes/PHPExcel/IOFactory.php";
-	
+
 	$upload = $_FILES["upload"]["tmp_name"]; // actual file
 	$fileName = $_FILES["upload"]["name"]; // original file name
-	
+
 	$tag = $fileName;
-	
-	
+
 	$obj = PHPExcel_IOFactory::load($upload);
 	//$obj->setReadDataOnly(true);
-	
+
 	echo "Spreadsheet Loaded: <b>$fileName</b> <br/>";
-	
+
 	clean_posts($tag);
-	
+
 	/*
 	foreach ($obj->getWorksheetIterator() as $worksheet) {
 		//print_r($worksheet);
-		
+
 		foreach ($worksheet->getRowIterator() as $row) {
-			
-			
+
+
 		}
-		
+
 	}
 	*/
-	
-	
+
 	//return;
-	
+
 	$loadedSheetNames = $obj->getSheetNames();
-	
+
 	foreach($loadedSheetNames as $sheetIndex => $loadedSheetName) {
 		echo "<p>";
 		$sheet = $obj->getSheet($sheetIndex)->toArray(null, true, true, true);
-		
+
 		switch(strtolower($loadedSheetName)) {
-			case "semester breakdown": 
+			case "semester breakdown":
 				echo "<h3>Semester Overview</h3><br/>";
-			
+
 				// main sheet detailing semester breakdowns
 				$yearSpan = explode("-", $sheet[1][A]);
-				
+
 				$yearStart = trim($yearSpan[0]);
 				$yearEnd = trim($yearSpan[1]);
-				
-				
+
 				$semesters = process_overview($sheet);
 				//print_r($semesters);
 				break;
 			case "holidays & special hours":
 				echo "<h3>Holiday Sheet</h3><br/>";
-				
+
 				process_holiday($sheet, $tag);
-				
+
 				break;
 			default:
 				$semester = $sheet[1][A];
 				echo "<h3>Semester Sheet: $semester</h3>";
-				
+
 				process_semester($sheet, $semester, $semesters, $tag);
-				
-				
+
 				break;
 		}
-		
-		
-		
+
 	}
-	
-	
-	
-	
+
 	echo "<p><hr></p><b>Upload Completed</b>";
 }
 
@@ -761,22 +723,22 @@ function getSemester($name, $list) {
 
 function clean_posts($tag) {
 	echo "Removing Earlier Posts<br/>";
-	
+
 	// Insert Post
 	$args = array(
 		'post_type' => 'hours',
 		'meta_key' => 'tag',
 		'meta_value' => $tag,
 		'posts_per_page' => -1,
-	);	
-	
+	);
+
 	$toDelete = new WP_Query( $args );
-	
+
 	while($toDelete->have_posts()) {
 		$toDelete->the_post();
-	
+
 		$deleteId = get_the_ID();
-			
+
 		wp_delete_post($deleteId, 1);
 	}
 }
@@ -789,7 +751,7 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 	$semesterEntry = getSemester($name, $semesterList);
 	$startDate = date("Ymd", $semesterEntry[start]);
 	$endDate = date("Ymd", $semesterEntry[end]);
-	
+
 	// get column / day relationship
 	foreach($arSheet as $row => $item) {
 		if (strtolower($item[A]) == "location") {
@@ -799,56 +761,53 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 		} else if ($row >= $startRow && $item[A] != "" && $foundMaster) {
 			// valid row and we have a master row to compare against
 			$started = 1;
-			
+
 			$locationName = $item[A];
 			$locationId = locationNameToId($locationName);
-			
+
 			echo "<br/><b>$locationName</b><br/>";
 			if ($locationId == 0) {
 				echo "ERROR - Cannot Find Related Location<br/>";
-				
+
 			} else {
-			
+
 				/** Check if Semester exists for location **/
 				$semId = semesterNameToId($name, $locationId);
-				
+
 				if ($semId == 0) {
 					echo "Note - Semester Doesn't Exist, Creating New Semester<br/>";
-					
+
 					$args = array(
 						'post_title' => $name,
 						'post_parent' => $locationId,
 						'post_type' => 'hours',
 						'post_status' => 'publish'
 					);
-					
+
 					$semId = wp_insert_post($args);
-					
+
 					add_post_meta($semId, "start", $startDate);
 					add_post_meta($semId, "end", $endDate);
 					add_post_meta($semId, "is_term", 1);
 					add_post_meta($semId, "tag", "TERM:".$tag);
-					
-					
+
 					echo "Created New Semester<br/>";
-					
+
 				} else {
 					update_post_meta($semId, "start", $startDate);
 					update_post_meta($semId, "end", $endDate);
 				}
-				
-				
+
 				/** Look at hours for the semester **/
-				
+
 				foreach($item as $col => $val) {
 					if ($col != 'A') {
 						// not the name
-						
+
 						$day = $masterRow[$col];
 						if ($val != "") {
 							echo "Adding - ".$day." = ".$val."<br>";
-							
-							
+
 							// Insert Post
 							$args = array(
 								'post_title' => $day,
@@ -856,24 +815,20 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 								'post_type' => 'hours',
 								'post_status' => 'publish'
 							);
-							
+
 							$postId = wp_insert_post($args);
-							
+
 							$val = str_replace(":00", "", $val);
-							
+
 							add_post_meta($postId, "description", $val);
 							add_post_meta($postId, "tag", $tag);
-							
+
 						}
-						
-						
-						
+
 					}
 				}
 			}
-			
-			
-			
+
 		} else {
 			// catch hidden extra areas
 			if ($started && $item[A] == "") {
@@ -881,19 +836,17 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 			}
 		}
 	}
-	
-}	
+
+}
 
 
 
 function process_holiday($arSheet, $tag) {
 	global $resetCache;
-	
+
 	$resetCache = 1;
 	$arHours = getHours();
 	$resetCache = 0;
-			
-
 
 	$startRow = 4;
 	$started = 0;
@@ -903,7 +856,7 @@ function process_holiday($arSheet, $tag) {
 	$semesterEntry = getSemester($name, $semesterList);
 	$startDate = date("Ymd", $semesterEntry[start]);
 	$endDate = date("Ymd", $semesterEntry[end]);
-	
+
 	// get column / day relationship
 	foreach($arSheet as $row => $item) {
 		if (strtolower($item[A]) == "holiday") {
@@ -917,50 +870,46 @@ function process_holiday($arSheet, $tag) {
 		} else if ($row >= $startRow && $item[A] != "" && $foundMaster && foundDate) {
 			// valid row and we have a master row to compare against
 			$started = 1;
-			
+
 			$locationName = $item[A];
 			$locationId = locationNameToId($locationName);
 			$locationIdOriginal = locationNameToIdOriginal($locationName);
-			
+
 			echo "<b>$locationName </b><br/>";
 			if ($locationId == 0) {
 				echo "ERROR - Cannot Find Related Location<br/>";
-				
-			} else {
-			
 
-			
-			
+			} else {
+
 				/** Look at hours for the semester **/
-				
+
 				foreach($item as $col => $val) {
 					if ($col != 'A') {
 						// not the name
-						
+
 						// use master row, if not, use previous (for blank entries);
 						if ($masterRow[$col] != "")
 							$day = $masterRow[$col];
 						$dt = strtotime($dateRow[$col]);
 						$formatDate = date("Ymd", $dt);
 						$termDate = date("Y-m-d", $dt);
-						
+
 						if ($val != "") {
-						
+
 							/** Check if term exists for location **/
 							$termId = 0;
 							$term = getTerm($arHours, $locationIdOriginal, $dt);
-							
+
 							//print_r($term[term]);
 							$termId = $term[term][id];
-							
+
 							echo "Adding Holiday - ".$day." / ".$formatDate." = ".$val."<br>";
-							
+
 							if ($termId ==0 || $termId == "") {
 								echo "<b>MISSING Term for: $termDate</b><br>";
 							} else {
 								// OK to insert
-							
-							
+
 								// Insert Post
 								$args = array(
 									'post_title' => $day,
@@ -968,27 +917,23 @@ function process_holiday($arSheet, $tag) {
 									'post_type' => 'hours',
 									'post_status' => 'publish'
 								);
-								
+
 								$postId = wp_insert_post($args);
-								
+
 								$val = str_replace(":00", "", $val);
-								
-								add_post_meta($postId, "start", $formatDate);						
+
+								add_post_meta($postId, "start", $formatDate);
 								add_post_meta($postId, "description", $val);
 								add_post_meta($postId, "tag", $tag);
-								
+
 							}
-							
+
 						}
-						
-						
-						
+
 					}
 				}
 			}
-			
-			
-			
+
 		} else {
 			// catch hidden extra areas
 			if ($started && $item[A] == "") {
@@ -996,8 +941,8 @@ function process_holiday($arSheet, $tag) {
 			}
 		}
 	}
-	
-}	
+
+}
 
 function semesterNameToId($name, $locationId) {
 	$args = array(
@@ -1006,36 +951,36 @@ function semesterNameToId($name, $locationId) {
 		'search_prod_title' => $name,
 		'post_parent' => $locationId,
 	);
-	
+
 	add_filter( 'posts_where', 'title_filter', 10, 2 );
 	$semList = new WP_Query( $args );
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
-	
+
 	if ($semList->have_posts()) {
 		$semList -> the_post();
-		
+
 		return get_the_ID();
-		
-	};	
-	
+
+	};
+
 	return 0;
 }
 
 function nameLookup($name) {
 	switch(strtolower($name)) {
-		case "barker":	
+		case "barker":
 			$baseName = "Barker Library";
 			break;
-		case "dewey":	
+		case "dewey":
 			$baseName = "Dewey Library";
 			break;
-		case "hayden":	
+		case "hayden":
 			$baseName = "Hayden Library";
 			break;
-		case "rotch":	
+		case "rotch":
 			$baseName = "Rotch Library";
 			break;
-		case "lewis":	
+		case "lewis":
 			$baseName = "Lewis Music Library";
 			break;
 		case "maihaugen":
@@ -1047,61 +992,60 @@ function nameLookup($name) {
 		case "archives":
 			$baseName = "Institute Archives & Special Collections";
 			break;
-			
+
 		case "administrative":
 			$baseName = "Administrative Offices";
 			break;
-			
+
 		case "document services":
 		case "ds":
 			$baseName = "Document Services";
 			break;
-			
+
 		case "gis":
 			$baseName = "Geographic Information Systems (GIS) Laboratory";
 			break;
-			
+
 		case "lsa":
 			$baseName = "Library Storage Annex";
 			break;
-			
+
 		case "digital image services":
 		case "dis":
 			$baseName = "Digital Image Services & Visual Collections";
 			break;
-			
-		default: 
+
+		default:
 			$baseName = $name;
 	}
-	return $baseName;	
+	return $baseName;
 }
 
 function locationNameToId($name) {
 	$baseName = nameLookup($name);
 	$id = 0;
-	
+
 	$args = array(
 		'post_type' => 'hours',
 		'posts_per_page' => -1,
 		'search_prod_title' => $baseName,
 		'post_parent' => 0,
 	);
-	
+
 	add_filter( 'posts_where', 'title_filter', 10, 2 );
 	$locationList = new WP_Query( $args );
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
-	
+
 	if ($locationList->have_posts()) {
 		$locationList -> the_post();
-		
+
 		return get_the_ID();
-		
+
 	};
-	
+
 	// didn't find
 	return 0;
-	
-	
+
 }
 
 
@@ -1110,30 +1054,29 @@ function locationNameToIdOriginal($name) {
 
 	$baseName = nameLookup($name);
 	$id = 0;
-	
+
 	$args = array(
 		'post_type' => 'hours',
 		'posts_per_page' => -1,
 		'search_prod_title' => $baseName,
 		'post_parent' => 0,
 	);
-	
+
 	add_filter( 'posts_where', 'title_filter', 10, 2 );
 	$locationList = new WP_Query( $args );
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
-	
+
 	if ($locationList->have_posts()) {
 		$locationList -> the_post();
 		$id = get_post_meta(get_the_ID(), "associated_location", true);
-		
+
 		return $id;
-		
+
 	};
-	
+
 	// didn't find
 	return 0;
-	
-	
+
 }
 
 
@@ -1148,56 +1091,55 @@ function title_filter( $where, &$wp_query )
 
 function process_overview($arSheet) {
 	$startRow = 4;
-	
+
 	$rObj = array();
-	
+
 	foreach($arSheet as $row => $item) {
 		if ($row >= $startRow ) {
 			if ($item[A] != "") {
 				$semester = $item[A];
 				$start = strtotime($item[B]);
 				$end = strtotime($item[C]);
-				
+
 				$temp = array();
-				
+
 				echo "<b>$semester</b>: ".date("Y-m-d", $start)." to ".date("Y-m-d", $end)." <br>";
-				
+
 				$temp[semester] = $semester;
 				$temp[start] = $start;
 				$temp[end] = $end;
-				
+
 				array_push($rObj, $temp);
 			}
 		}
 	}
-	
+
 	return $rObj;
 }
 
 function getTermHours($term, $type) {
 	$arOut = array();
-	
+
 	$arClosings = array();
 	$arExceptions = array();
 	$arRegular = array();
-	
+
 	$hours = $term[hours];
-	
+
 	foreach($hours as $hour) {
 		//print_r($hour);
 		$name = $hour[name];
 		$desc = $hour[description];
 		$dates = array(
 			"start" => date("Y-m-d", strtotime($hour[start]))
-		);			
-		
+		);
+
 		if ($hour[end]) {
 			$dates["end"] = date("Y-m-d", strtotime($hour[end]));
 		} else {
 			$dates["end"] = date("Y-m-d", strtotime($hour[start]));
 		}
-		
-		
+
 		$hrs = getHourHours($hour);
 
 		if (checkClosed($desc)) {
@@ -1205,11 +1147,11 @@ function getTermHours($term, $type) {
 			$arDay = array(
 				"dates" => $dates,
 				"reason" => $name
-				
+
 			);
 			//print_r($dates);
 			array_push($arClosings, $arDay);
-			
+
 		} else if (checkWeekday($name)) {
 			//echo "Weekday";
 			$arDay = array(
@@ -1218,7 +1160,7 @@ function getTermHours($term, $type) {
 				"note" => ""
 			);
 			array_push($arRegular, $arDay);
-			
+
 		} else {
 			//echo "Exception";
 			$arDay = array(
@@ -1228,12 +1170,11 @@ function getTermHours($term, $type) {
 			);
 			//print_r($dates);
 			array_push($arExceptions, $arDay);
-		
+
 		}
-			
+
 	}
-	
-	
+
 	switch($type) {
 		case "closings":
 			return $arClosings;
@@ -1245,50 +1186,47 @@ function getTermHours($term, $type) {
 			return $arRegular;
 			break;
 	}
-	
+
 }
 
 function getExport($location) {
 	$hours = getHours();
 
 	$locationId = locationNameToId($location);
-	
+
 	$name = nameLookup($location);
 
 	$locationObjectId = get_post_meta($locationId, "associated_location", true);
-	
+
 	$building = get_post_meta($locationObjectId, "building", true);
 	$phone = get_post_meta($locationObjectId, "phone", true);
-	
+
 	$terms = $hours[$locationObjectId][terms];
-	
+
 	$arTerms = array();
-	
+
 	foreach($terms as $term) {
 		//print_r($term);
 		$outTerm = array();
-		
+
 		$outTerm[name] = $term[name];
-		
+
 		$dates = array();
 		$dates[start] = date("Y-m-d", strtotime($term[start]));
 		$dates[end] = date("Y-m-d", strtotime($term[end]));
-		
-		
+
 		$closings = getTermHours($term, "closings");
 		$exceptions = getTermHours($term, "exceptions");
 		$regular = getTermHours($term, "regular");
-				
+
 		$outTerm[dates] = $dates;
 		$outTerm[closings] = $closings;
 		$outTerm[exceptions] = $exceptions;
 		$outTerm[regular] = $regular;
-		
-		
-		
+
 		array_push($arTerms, $outTerm);
 	}
-	
+
 	$arExport = array(
 		"name" => $name,
 		"location" => $building,
@@ -1296,11 +1234,8 @@ function getExport($location) {
 		"terms" => $arTerms
 	);
 
-	
-	
 	//$arExport[name] = $name;
-		
-		
+
 	$export = $arExport;
 	return $export;
 }

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -14,8 +14,8 @@ $halfCache = 0;
 if (isset($_GET["locReset"]))
 	$locationReset = $_GET["locReset"];
 
-$expireLong = 60*5; // 24 hours
-$expireShort = 60*5; // 5 minutes
+$expireLong = 60 * 5; // 24 hours
+$expireShort = 60 * 5; // 5 minutes
 date_default_timezone_set("America/New_York");
 
 function getHours() {
@@ -154,7 +154,7 @@ function hasHours( $locationId, $curDay ) {
 
 		$term = getTerm($arHours, $locationId, $dt);
 
-		if ( count($term)==0 ) {
+		if ( count($term) == 0 ) {
 			// no hours
 			$data = 0;
 		} else {
@@ -187,10 +187,10 @@ function getHoursDay( $locationId, $dt ) {
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
 
-		if ( count($term)==0 ) {
+		if ( count($term) == 0 ) {
 			// no hours
 			$data = "TBA";
-		} else if ( count($hour)==0 ) {
+		} else if ( count($hour) == 0 ) {
 			// no hours
 			$data = "TBA";
 		} else {
@@ -223,10 +223,10 @@ function getMobileHoursDay( $locationId, $dt ) {
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
 
-		if ( count($term)==0 ) {
+		if ( count($term) == 0 ) {
 			// no hours
 			$data = "TBA";
-		} else if ( count($hour)==0 ) {
+		} else if ( count($hour) == 0 ) {
 			// no hours
 			$data = "TBA";
 		} else {
@@ -281,12 +281,12 @@ function getOpen( $locationId ) {
 	$term = getTerm($arHours, $locationId, $dt);
 	$hour = getTermHour($term, $dt);
 
-	if ( count($term)==0 ) {
+	if ( count($term) == 0 ) {
 		// no hours
 		return false;
 	}
 
-	if ( count($hour)==0 ) {
+	if ( count($hour) == 0 ) {
 		// no hours
 		return false;
 	}
@@ -482,8 +482,8 @@ function getTerm( $obj, $location, $dt ) {
 				if ( $start <= $dt && $dt <= $end ) {
 					//echo "FOUND";
 					$data = array(
-						"id"=>$key,
-						"term"=>$term
+						"id" => $key,
+						"term" => $term
 					);
 				}
 }
@@ -743,7 +743,7 @@ function clean_posts( $tag ) {
 function process_semester( $arSheet, $name, $semesterList, $tag ) {
 	$startRow = 4;
 	$started = 0;
-	$foundMaster= 0;
+	$foundMaster = 0;
 
 	$semesterEntry = getSemester($name, $semesterList);
 	$startDate = date("Ymd", $semesterEntry[start]);
@@ -845,7 +845,7 @@ function process_holiday( $arSheet, $tag ) {
 
 	$startRow = 4;
 	$started = 0;
-	$foundMaster= 0;
+	$foundMaster = 0;
 	$foundDate = 0;
 
 	$semesterEntry = getSemester($name, $semesterList);
@@ -900,7 +900,7 @@ function process_holiday( $arSheet, $tag ) {
 
 							echo "Adding Holiday - ".$day." / ".$formatDate." = ".$val."<br>";
 
-							if ( $termId ==0 || $termId == "" ) {
+							if ( $termId == 0 || $termId == "" ) {
 								echo "<b>MISSING Term for: $termDate</b><br>";
 							} else {
 								// OK to insert

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -1,6 +1,6 @@
 <?php
 
-if (isset($_GET["cleanCache"])) {
+if ( isset($_GET["cleanCache"]) ) {
 	$clean = $_GET["cleanCache"];
 } else {
 	$clean = 0;
@@ -25,7 +25,7 @@ function getHours() {
 	$expire = $expireShort;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache) {
+	if ( $data === false || $resetCache ) {
 
 		// gets the entire hours object;
 		global $post;
@@ -39,7 +39,7 @@ function getHours() {
 		);
 
 		$hours = new WP_Query( $args );
-		while($hours->have_posts()):
+		while ( $hours->have_posts() ) :
 
 			$hours->the_post();
 			$id = get_the_ID();
@@ -80,7 +80,7 @@ function getHours() {
 	return $data;
 }
 
-function getHoursChildren($parent) {
+function getHoursChildren( $parent ) {
 	$arHours = array();
 
 	$args = array(
@@ -93,7 +93,7 @@ function getHoursChildren($parent) {
 
 	$hours = new WP_Query( $args );
 
-	while($hours->have_posts()):
+	while ( $hours->have_posts() ) :
 
 		$hours->the_post();
 		$id = get_the_ID();
@@ -125,21 +125,21 @@ function getHoursChildren($parent) {
 	return $arHours;
 }
 
-function getHoursToday($locationId) {
+function getHoursToday( $locationId ) {
 	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$date = date("Y-m-d");
 	$key = "getHoursToday-$locationId-$date";
 	$expire = $expireShort;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache || $locationReset == $locationId) {
+	if ( $data === false || $resetCache || $locationReset == $locationId ) {
 		$data = getHoursDay($locationId, strtotime("Now"));
 		set_transient( $key, $data, $expire );
 	}
 	return $data;
 }
 
-function hasHours($locationId, $curDay) {
+function hasHours( $locationId, $curDay ) {
 	global $resetCache, $expireLong, $expireShort, $locationReset;
 
 	$date = date("Y-m-d", strtotime($curDay));
@@ -147,14 +147,14 @@ function hasHours($locationId, $curDay) {
 	$expire = $expireShort;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache || $locationReset == $locationId) {
+	if ( $data === false || $resetCache || $locationReset == $locationId ) {
 		$arHours = getHours();
 
 		$dt = strtotime($curDay);
 
 		$term = getTerm($arHours, $locationId, $dt);
 
-		if (count($term)==0) {
+		if ( count($term)==0 ) {
 			// no hours
 			$data = 0;
 		} else {
@@ -166,13 +166,13 @@ function hasHours($locationId, $curDay) {
 	return $data;
 }
 
-function getHoursDay($locationId, $dt) {
+function getHoursDay( $locationId, $dt ) {
 	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$key = "getHoursDay-$locationId-$dt";
 	$expire = $expireShort;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache || $locationReset == $locationId) {
+	if ( $data === false || $resetCache || $locationReset == $locationId ) {
 
 		$data = "";
 		$today = $dt;
@@ -187,10 +187,10 @@ function getHoursDay($locationId, $dt) {
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
 
-		if (count($term)==0) {
+		if ( count($term)==0 ) {
 			// no hours
 			$data = "TBA";
-		} else if (count($hour)==0) {
+		} else if ( count($hour)==0 ) {
 			// no hours
 			$data = "TBA";
 		} else {
@@ -202,13 +202,13 @@ function getHoursDay($locationId, $dt) {
 	return $data;
 }
 
-function getMobileHoursDay($locationId, $dt) {
+function getMobileHoursDay( $locationId, $dt ) {
 	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$key = "getMobileHoursDay-$locationId-$dt";
 	$expire = $expireShort;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache || $locationReset == $locationId) {
+	if ( $data === false || $resetCache || $locationReset == $locationId ) {
 
 		$data = "";
 		$today = $dt;
@@ -223,10 +223,10 @@ function getMobileHoursDay($locationId, $dt) {
 		//print_r($term);
 		$hour = getTermHour($term, $dt);
 
-		if (count($term)==0) {
+		if ( count($term)==0 ) {
 			// no hours
 			$data = "TBA";
-		} else if (count($hour)==0) {
+		} else if ( count($hour)==0 ) {
 			// no hours
 			$data = "TBA";
 		} else {
@@ -238,13 +238,13 @@ function getMobileHoursDay($locationId, $dt) {
 	return $data;
 }
 
-function getMessageDay($locationId, $dt) {
+function getMessageDay( $locationId, $dt ) {
 	global $resetCache, $expireLong, $expireShort, $locationReset;
 	$key = "getMessageDay-$locationId-$dt";
 	$expire = $expireShort;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache || $locationReset == $locationId) {
+	if ( $data === false || $resetCache || $locationReset == $locationId ) {
 
 		//echo date("Y-m-d", $dt);
 		$data = "";
@@ -262,7 +262,7 @@ function getMessageDay($locationId, $dt) {
 
 		$data = "";
 
-		if ($hour["show_spanning"] == 1) {
+		if ( $hour["show_spanning"] == 1 ) {
 			$data = $hour;
 		}
 
@@ -272,7 +272,7 @@ function getMessageDay($locationId, $dt) {
 }
 
 
-function getOpen($locationId) {
+function getOpen( $locationId ) {
 	$today = strtotime("Now");
 	$dt = $today;
 
@@ -281,12 +281,12 @@ function getOpen($locationId) {
 	$term = getTerm($arHours, $locationId, $dt);
 	$hour = getTermHour($term, $dt);
 
-	if (count($term)==0) {
+	if ( count($term)==0 ) {
 		// no hours
 		return false;
 	}
 
-	if (count($hour)==0) {
+	if ( count($hour)==0 ) {
 		// no hours
 		return false;
 	}
@@ -294,7 +294,7 @@ function getOpen($locationId) {
 	return checkOpen($hour, $dt);
 }
 
-function checkClosed($str) {
+function checkClosed( $str ) {
 	$str = strtolower($str);
 	if (
 		strpos($str, "closed") !== false ||
@@ -306,7 +306,7 @@ function checkClosed($str) {
 	return false;
 }
 
-function checkWeekday($str) {
+function checkWeekday( $str ) {
 	$str = strtolower($str);
 	if (
 		strpos($str, "monday") !== false ||
@@ -322,7 +322,7 @@ function checkWeekday($str) {
 	return false;
 }
 
-function checkOpen($hour, $dt) {
+function checkOpen( $hour, $dt ) {
 	$hrs = strtolower($hour["description"]);
 
 	if (
@@ -340,20 +340,20 @@ function checkOpen($hour, $dt) {
 
 	$start = strtotime($arRange[0]);
 
-	if ($arRange[1] == "midnight") {
+	if ( $arRange[1] == "midnight" ) {
 		$end = strtotime($arRange[1]." + 1 day");
 	} else {
 		$end = strtotime($arRange[1]);
 	}
 
-	if ($start <= $dt && $dt <= $end) {
+	if ( $start <= $dt && $dt <= $end ) {
 		return true;
 	}
 
 	return false;
 }
 
-function getHourHours($hour) {
+function getHourHours( $hour ) {
 	$arOut = array();
 
 	$hrs = strtolower($hour["description"]);
@@ -371,7 +371,7 @@ function getHourHours($hour) {
 
 	$start = strtotime($arRange[0]);
 
-	if ($arRange[1] == "midnight") {
+	if ( $arRange[1] == "midnight" ) {
 		$end = strtotime($arRange[1]." + 1 day");
 	} else {
 		$end = strtotime($arRange[1]);
@@ -384,10 +384,10 @@ function getHourHours($hour) {
 
 }
 
-function dayLookup($str) {
+function dayLookup( $str ) {
 	$str = strtolower(date("l", strtotime($str)));
 
-	switch($str) {
+	switch ( $str ) {
 		case "monday":
 			return "M";
 			break;
@@ -412,8 +412,8 @@ function dayLookup($str) {
 	}
 }
 
-function toDays($str) {
-	if (strpos($str, "-") !== false) {
+function toDays( $str ) {
+	if ( strpos($str, "-") !== false ) {
 		// multi day
 		//echo $str;
 		$arRange = explode("-", $str);
@@ -430,7 +430,7 @@ function toDays($str) {
 		$strOut = "";
 
 		//echo $currentShort." vs ".$endShort;
-		while($currentShort != $endShort) {
+		while ( $currentShort != $endShort ) {
 			$strOut .= $currentShort;
 
 			$current = date("l", strtotime($current." + 1 day"));
@@ -449,24 +449,24 @@ function toDays($str) {
 	return $str;
 }
 
-function getTerm($obj, $location, $dt) {
+function getTerm( $obj, $location, $dt ) {
 	global $resetCache, $expireLong, $expireShort, $locationReset;
 
 	$key = "getTerm-$location-$dt";
 	$expire = $expireLong;
 	$data = get_transient( $key );
 
-	if ($data === false || $resetCache || $location == $locationReset) {
+	if ( $data === false || $resetCache || $location == $locationReset ) {
 
 		$data = array();
 
-		if ($obj[$location]) {
+		if ( $obj[$location] ) {
 			// location exists
 			$arTerms = $obj[$location]["terms"];
 
 			//echo "[E: ".date("Y-m-d", $dt)." ]";
 
-			foreach($arTerms as $termId => $term) {
+			foreach ( $arTerms as $termId => $term ) {
 				$start = $term["start"];
 				$end = $term["end"];
 
@@ -479,17 +479,15 @@ function getTerm($obj, $location, $dt) {
 
 				//echo "[ ".date("Y-m-d", $start)." ]";
 
-				if ($start <= $dt && $dt <= $end) {
+				if ( $start <= $dt && $dt <= $end ) {
 					//echo "FOUND";
 					$data = array(
 						"id"=>$key,
 						"term"=>$term
 					);
 				}
-
-			}
-
-		} else {
+}
+} else {
 			//echo "TEST";
 		}
 
@@ -501,10 +499,10 @@ function getTerm($obj, $location, $dt) {
 	return $data;
 }
 
-function getTermHour($term, $dt) {
+function getTermHour( $term, $dt ) {
 	// check for special days
 
-	if (count($term) == 0) {
+	if ( count($term) == 0 ) {
 		return array();
 	}
 
@@ -513,10 +511,10 @@ function getTermHour($term, $dt) {
 	$arHours = $term["term"]["hours"];
 
 	// Special days
-	foreach($arHours as $hours) {
+	foreach ( $arHours as $hours ) {
 
 		$start = $hours["start"];
-		if ($start != "") {
+		if ( $start != "" ) {
 
 			$end = $hours["end"];
 
@@ -527,32 +525,32 @@ function getTermHour($term, $dt) {
 			$start = strtotime($start);
 			$end = strtotime($end);
 
-			if ($start <= $dt && $dt <= $end) {
+			if ( $start <= $dt && $dt <= $end ) {
 				return $hours;
 			}
 		}
 	}
 
 	// Day match
-	foreach($arHours as $hours) {
+	foreach ( $arHours as $hours ) {
 		$start = $hours["start"];
-		if ($start == "") {
+		if ( $start == "" ) {
 			// only normal days
 			$name = $hours["name"];
-			if ($name == $dtWeek) {
+			if ( $name == $dtWeek ) {
 				return $hours;
 			}
 		}
 	}
 
 	// Day Span Match
-	foreach($arHours as $hours) {
+	foreach ( $arHours as $hours ) {
 		$start = $hours["start"];
-		if ($start == "") {
+		if ( $start == "" ) {
 			// only span days
 			$name = $hours["name"];
-			if (strpos($name, "-") !== false) {
-				if (dateSpanFit($name, $dtWeek)) {
+			if ( strpos($name, "-") !== false ) {
+				if ( dateSpanFit($name, $dtWeek) ) {
 					return $hours;
 				} else {
 				}
@@ -563,7 +561,7 @@ function getTermHour($term, $dt) {
 	return array();
 }
 
-function dateSpanFit($range, $dt) {
+function dateSpanFit( $range, $dt ) {
 	$arRange = explode("-", $range);
 
 	$start = strtotime(trim($arRange[0]));
@@ -574,14 +572,14 @@ function dateSpanFit($range, $dt) {
 
 	$dtDay = date("N", strtotime($dt));
 
-	if ($startDay <= $dtDay && $dtDay <= $endDay) {
+	if ( $startDay <= $dtDay && $dtDay <= $endDay ) {
 		return true;
 	}
 
 	return false;
 }
 
-function hourToMobile($str) {
+function hourToMobile( $str ) {
 	// alters hours for mobile output (replacing long strings with shorter ones)
 	$str = str_replace("midnight", "midn", $str);
 	$str = str_replace("-", "<br/>", $str);
@@ -592,7 +590,7 @@ function hourToMobile($str) {
 	return $str;
 }
 
-function filterText($str) {
+function filterText( $str ) {
 	// alters hours for mobile output (replacing long strings with shorter ones)
 	//$str = str_replace("midnight", "midn", $str);
 	//$str = str_replace("-", "<br/>", $str);
@@ -628,11 +626,11 @@ function import_hours() {
 		</p>
 	</form>
 <?php
-	if (isset($_POST["import_spreadsheet"])) {
-		if (isset($_FILES["upload"]) && $_FILES["upload"]["name"] != "") {
+	if ( isset($_POST["import_spreadsheet"]) ) {
+		if ( isset($_FILES["upload"]) && $_FILES["upload"]["name"] != "" ) {
 			handle_hours_upload();
 		}
-		if (isset($_POST["tag_delete"]) && $_POST["tag_delete"] != "") {
+		if ( isset($_POST["tag_delete"]) && $_POST["tag_delete"] != "" ) {
 			clean_posts($_POST["tag_delete"]);
 			echo "Items removed with tag: ".$_POST["tag_delete"];
 		}
@@ -677,11 +675,11 @@ function handle_hours_upload() {
 
 	$loadedSheetNames = $obj->getSheetNames();
 
-	foreach($loadedSheetNames as $sheetIndex => $loadedSheetName) {
+	foreach ( $loadedSheetNames as $sheetIndex => $loadedSheetName ) {
 		echo "<p>";
 		$sheet = $obj->getSheet($sheetIndex)->toArray(null, true, true, true);
 
-		switch(strtolower($loadedSheetName)) {
+		switch ( strtolower($loadedSheetName) ) {
 			case "semester breakdown":
 				echo "<h3>Semester Overview</h3><br/>";
 
@@ -708,20 +706,19 @@ function handle_hours_upload() {
 
 				break;
 		}
-
-	}
+}
 
 	echo "<p><hr></p><b>Upload Completed</b>";
 }
 
-function getSemester($name, $list) {
-	foreach($list as $index => $item) {
+function getSemester( $name, $list ) {
+	foreach ( $list as $index => $item ) {
 		if ($item[semester] == $name) return $item;
 	}
 	return "";
 }
 
-function clean_posts($tag) {
+function clean_posts( $tag ) {
 	echo "Removing Earlier Posts<br/>";
 
 	// Insert Post
@@ -734,7 +731,7 @@ function clean_posts($tag) {
 
 	$toDelete = new WP_Query( $args );
 
-	while($toDelete->have_posts()) {
+	while ( $toDelete->have_posts() ) {
 		$toDelete->the_post();
 
 		$deleteId = get_the_ID();
@@ -743,7 +740,7 @@ function clean_posts($tag) {
 	}
 }
 
-function process_semester($arSheet, $name, $semesterList, $tag) {
+function process_semester( $arSheet, $name, $semesterList, $tag ) {
 	$startRow = 4;
 	$started = 0;
 	$foundMaster= 0;
@@ -753,12 +750,12 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 	$endDate = date("Ymd", $semesterEntry[end]);
 
 	// get column / day relationship
-	foreach($arSheet as $row => $item) {
-		if (strtolower($item[A]) == "location") {
+	foreach ( $arSheet as $row => $item ) {
+		if ( strtolower($item[A]) == "location" ) {
 			// row before it starts
 			$masterRow = $item;
 			$foundMaster = 1;
-		} else if ($row >= $startRow && $item[A] != "" && $foundMaster) {
+		} else if ( $row >= $startRow && $item[A] != "" && $foundMaster ) {
 			// valid row and we have a master row to compare against
 			$started = 1;
 
@@ -766,7 +763,7 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 			$locationId = locationNameToId($locationName);
 
 			echo "<br/><b>$locationName</b><br/>";
-			if ($locationId == 0) {
+			if ( $locationId == 0 ) {
 				echo "ERROR - Cannot Find Related Location<br/>";
 
 			} else {
@@ -774,7 +771,7 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 				/** Check if Semester exists for location **/
 				$semId = semesterNameToId($name, $locationId);
 
-				if ($semId == 0) {
+				if ( $semId == 0 ) {
 					echo "Note - Semester Doesn't Exist, Creating New Semester<br/>";
 
 					$args = array(
@@ -800,12 +797,12 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 
 				/** Look at hours for the semester **/
 
-				foreach($item as $col => $val) {
-					if ($col != 'A') {
+				foreach ( $item as $col => $val ) {
+					if ( $col != 'A' ) {
 						// not the name
 
 						$day = $masterRow[$col];
-						if ($val != "") {
+						if ( $val != "" ) {
 							echo "Adding - ".$day." = ".$val."<br>";
 
 							// Insert Post
@@ -824,14 +821,12 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 							add_post_meta($postId, "tag", $tag);
 
 						}
-
-					}
+}
 				}
 			}
-
-		} else {
+} else {
 			// catch hidden extra areas
-			if ($started && $item[A] == "") {
+			if ( $started && $item[A] == "" ) {
 				return;
 			}
 		}
@@ -841,7 +836,7 @@ function process_semester($arSheet, $name, $semesterList, $tag) {
 
 
 
-function process_holiday($arSheet, $tag) {
+function process_holiday( $arSheet, $tag ) {
 	global $resetCache;
 
 	$resetCache = 1;
@@ -858,16 +853,16 @@ function process_holiday($arSheet, $tag) {
 	$endDate = date("Ymd", $semesterEntry[end]);
 
 	// get column / day relationship
-	foreach($arSheet as $row => $item) {
-		if (strtolower($item[A]) == "holiday") {
+	foreach ( $arSheet as $row => $item ) {
+		if ( strtolower($item[A]) == "holiday" ) {
 			// row before it starts
 			$masterRow = $item;
 			$foundMaster = 1;
-		} else if (strtolower($item[A]) == "date") {
+		} else if ( strtolower($item[A]) == "date" ) {
 			// row before it starts
 			$dateRow = $item;
 			$foundDate = 1;
-		} else if ($row >= $startRow && $item[A] != "" && $foundMaster && foundDate) {
+		} else if ( $row >= $startRow && $item[A] != "" && $foundMaster && foundDate ) {
 			// valid row and we have a master row to compare against
 			$started = 1;
 
@@ -876,15 +871,15 @@ function process_holiday($arSheet, $tag) {
 			$locationIdOriginal = locationNameToIdOriginal($locationName);
 
 			echo "<b>$locationName </b><br/>";
-			if ($locationId == 0) {
+			if ( $locationId == 0 ) {
 				echo "ERROR - Cannot Find Related Location<br/>";
 
 			} else {
 
 				/** Look at hours for the semester **/
 
-				foreach($item as $col => $val) {
-					if ($col != 'A') {
+				foreach ( $item as $col => $val ) {
+					if ( $col != 'A' ) {
 						// not the name
 
 						// use master row, if not, use previous (for blank entries);
@@ -894,7 +889,7 @@ function process_holiday($arSheet, $tag) {
 						$formatDate = date("Ymd", $dt);
 						$termDate = date("Y-m-d", $dt);
 
-						if ($val != "") {
+						if ( $val != "" ) {
 
 							/** Check if term exists for location **/
 							$termId = 0;
@@ -905,7 +900,7 @@ function process_holiday($arSheet, $tag) {
 
 							echo "Adding Holiday - ".$day." / ".$formatDate." = ".$val."<br>";
 
-							if ($termId ==0 || $termId == "") {
+							if ( $termId ==0 || $termId == "" ) {
 								echo "<b>MISSING Term for: $termDate</b><br>";
 							} else {
 								// OK to insert
@@ -927,16 +922,13 @@ function process_holiday($arSheet, $tag) {
 								add_post_meta($postId, "tag", $tag);
 
 							}
-
-						}
-
-					}
+}
+}
 				}
 			}
-
-		} else {
+} else {
 			// catch hidden extra areas
-			if ($started && $item[A] == "") {
+			if ( $started && $item[A] == "" ) {
 				return;
 			}
 		}
@@ -944,7 +936,7 @@ function process_holiday($arSheet, $tag) {
 
 }
 
-function semesterNameToId($name, $locationId) {
+function semesterNameToId( $name, $locationId ) {
 	$args = array(
 		'post_type' => 'hours',
 		'posts_per_page' => -1,
@@ -956,7 +948,7 @@ function semesterNameToId($name, $locationId) {
 	$semList = new WP_Query( $args );
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
 
-	if ($semList->have_posts()) {
+	if ( $semList->have_posts() ) {
 		$semList -> the_post();
 
 		return get_the_ID();
@@ -966,8 +958,8 @@ function semesterNameToId($name, $locationId) {
 	return 0;
 }
 
-function nameLookup($name) {
-	switch(strtolower($name)) {
+function nameLookup( $name ) {
+	switch ( strtolower($name) ) {
 		case "barker":
 			$baseName = "Barker Library";
 			break;
@@ -1021,7 +1013,7 @@ function nameLookup($name) {
 	return $baseName;
 }
 
-function locationNameToId($name) {
+function locationNameToId( $name ) {
 	$baseName = nameLookup($name);
 	$id = 0;
 
@@ -1036,7 +1028,7 @@ function locationNameToId($name) {
 	$locationList = new WP_Query( $args );
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
 
-	if ($locationList->have_posts()) {
+	if ( $locationList->have_posts() ) {
 		$locationList -> the_post();
 
 		return get_the_ID();
@@ -1049,7 +1041,7 @@ function locationNameToId($name) {
 }
 
 
-function locationNameToIdOriginal($name) {
+function locationNameToIdOriginal( $name ) {
 	// looks for a manual match to the import name (names are converted to lowercase to eliminate capitalizations changes)
 
 	$baseName = nameLookup($name);
@@ -1066,7 +1058,7 @@ function locationNameToIdOriginal($name) {
 	$locationList = new WP_Query( $args );
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
 
-	if ($locationList->have_posts()) {
+	if ( $locationList->have_posts() ) {
 		$locationList -> the_post();
 		$id = get_post_meta(get_the_ID(), "associated_location", true);
 
@@ -1080,8 +1072,7 @@ function locationNameToIdOriginal($name) {
 }
 
 
-function title_filter( $where, &$wp_query )
-{
+function title_filter( $where, &$wp_query ) {
 	global $wpdb;
 	if ( $search_term = $wp_query->get( 'search_prod_title' ) ) {
 		$where .= ' AND ' . $wpdb->posts . '.post_title LIKE \'%' . esc_sql( like_escape( $search_term ) ) . '%\'';
@@ -1089,14 +1080,14 @@ function title_filter( $where, &$wp_query )
 	return $where;
 }
 
-function process_overview($arSheet) {
+function process_overview( $arSheet ) {
 	$startRow = 4;
 
 	$rObj = array();
 
-	foreach($arSheet as $row => $item) {
-		if ($row >= $startRow ) {
-			if ($item[A] != "") {
+	foreach ( $arSheet as $row => $item ) {
+		if ( $row >= $startRow ) {
+			if ( $item[A] != "" ) {
 				$semester = $item[A];
 				$start = strtotime($item[B]);
 				$end = strtotime($item[C]);
@@ -1117,7 +1108,7 @@ function process_overview($arSheet) {
 	return $rObj;
 }
 
-function getTermHours($term, $type) {
+function getTermHours( $term, $type ) {
 	$arOut = array();
 
 	$arClosings = array();
@@ -1126,7 +1117,7 @@ function getTermHours($term, $type) {
 
 	$hours = $term[hours];
 
-	foreach($hours as $hour) {
+	foreach ( $hours as $hour ) {
 		//print_r($hour);
 		$name = $hour[name];
 		$desc = $hour[description];
@@ -1134,7 +1125,7 @@ function getTermHours($term, $type) {
 			"start" => date("Y-m-d", strtotime($hour[start]))
 		);
 
-		if ($hour[end]) {
+		if ( $hour[end] ) {
 			$dates["end"] = date("Y-m-d", strtotime($hour[end]));
 		} else {
 			$dates["end"] = date("Y-m-d", strtotime($hour[start]));
@@ -1142,7 +1133,7 @@ function getTermHours($term, $type) {
 
 		$hrs = getHourHours($hour);
 
-		if (checkClosed($desc)) {
+		if ( checkClosed($desc) ) {
 			//echo "Closed";
 			$arDay = array(
 				"dates" => $dates,
@@ -1152,7 +1143,7 @@ function getTermHours($term, $type) {
 			//print_r($dates);
 			array_push($arClosings, $arDay);
 
-		} else if (checkWeekday($name)) {
+		} else if ( checkWeekday($name) ) {
 			//echo "Weekday";
 			$arDay = array(
 				"days" => toDays($name),
@@ -1172,10 +1163,9 @@ function getTermHours($term, $type) {
 			array_push($arExceptions, $arDay);
 
 		}
+}
 
-	}
-
-	switch($type) {
+	switch ( $type ) {
 		case "closings":
 			return $arClosings;
 			break;
@@ -1189,7 +1179,7 @@ function getTermHours($term, $type) {
 
 }
 
-function getExport($location) {
+function getExport( $location ) {
 	$hours = getHours();
 
 	$locationId = locationNameToId($location);
@@ -1205,7 +1195,7 @@ function getExport($location) {
 
 	$arTerms = array();
 
-	foreach($terms as $term) {
+	foreach ( $terms as $term ) {
 		//print_r($term);
 		$outTerm = array();
 

--- a/lib/news.php
+++ b/lib/news.php
@@ -3,8 +3,8 @@
 * Front page news functions
 *
 * These functions are called by page-home-direct.php, and control the loading
-* of news items from a separate site on the network. This process is 
-* documented online at: 
+* of news items from a separate site on the network. This process is
+* documented online at:
 * https://github.com/mitlibraries-ux/MITlibraries-parent/wiki/News
 *
 */
@@ -38,7 +38,7 @@ function LoadNews() {
     $pool = RetrievePool();
 
     if(count($pool) != 2) {
-        // If there are anything other than two items in the pool, then we 
+        // If there are anything other than two items in the pool, then we
         // summarize the pool and determine query type
         $queryType = SummarizePool($pool);
 
@@ -49,7 +49,7 @@ function LoadNews() {
             $pool = QueryPoolOne();
         }
     }
-    
+
     RenderPool($pool);
 
     // Restore context back to current site
@@ -212,7 +212,7 @@ function RenderPool($items) {
 }
 
 function RetrievePool() {
-    // This characterizes the pool of eligible articles, and then calls the 
+    // This characterizes the pool of eligible articles, and then calls the
     // relevant query builder
 
     // Get all eligible articles
@@ -233,12 +233,12 @@ function RetrievePool() {
     $items = get_posts( $args );
 
     return $items;
-    
+
 }
 
 function SummarizePool($items) {
     // This takes the pool of all eligible news items, determines how many of
-    // each type exist, and determines what type of query is needed to 
+    // each type exist, and determines what type of query is needed to
     // populate the front page.
 
     // Summarize article list

--- a/lib/news.php
+++ b/lib/news.php
@@ -12,268 +12,268 @@
 $newsBlogID = 7;
 
 function DebugNews() {
-    global $newsBlogID;
+	global $newsBlogID;
 
-    echo '<!-- Loading featured news items -->';
+	echo '<!-- Loading featured news items -->';
 
-    // Switch context to news site
-    switch_to_blog($newsBlogID);
+	// Switch context to news site
+	switch_to_blog($newsBlogID);
 
-    $pool = RetrievePool();
+	$pool = RetrievePool();
 
-    RenderPool($pool);
+	RenderPool($pool);
 
-    // Restore context back to current site
-    restore_current_blog();
+	// Restore context back to current site
+	restore_current_blog();
 }
 
 function LoadNews() {
-    global $newsBlogID;
+	global $newsBlogID;
 
-    echo '<!-- Loading featured news items -->';
+	echo '<!-- Loading featured news items -->';
 
-    // Switch context to news site
-    switch_to_blog($newsBlogID);
+	// Switch context to news site
+	switch_to_blog($newsBlogID);
 
-    $pool = RetrievePool();
+	$pool = RetrievePool();
 
-    if(count($pool) != 2) {
-        // If there are anything other than two items in the pool, then we
-        // summarize the pool and determine query type
-        $queryType = SummarizePool($pool);
+	if(count($pool) != 2) {
+		// If there are anything other than two items in the pool, then we
+		// summarize the pool and determine query type
+		$queryType = SummarizePool($pool);
 
-        // Build the appropriate item pool
-        if($queryType === 'two') {
-            $pool = QueryPoolTwo();
-        } else {
-            $pool = QueryPoolOne();
-        }
-    }
+		// Build the appropriate item pool
+		if($queryType === 'two') {
+			$pool = QueryPoolTwo();
+		} else {
+			$pool = QueryPoolOne();
+		}
+	}
 
-    RenderPool($pool);
+	RenderPool($pool);
 
-    // Restore context back to current site
-    restore_current_blog();
+	// Restore context back to current site
+	restore_current_blog();
 }
 
 function QueryPoolTwo() {
-    // This builds a recordset for two post/bibliotech articles
+	// This builds a recordset for two post/bibliotech articles
 
-    $args = array(
-        'meta_query' => array(
-            array(
-                'key' => 'featuredArticle',
-                'value' => 'True',
-                'compare' => '='
-                ),
-            ),
-        'post_type' => array( 'post' , 'bibliotech'),
-        'post_status' => 'publish',
-        'posts_per_page' => 2,
-        'orderby' => 'rand',
-        'ignore_sticky_posts' => 1
-    );
-    $items = get_posts( $args );
+	$args = array(
+		'meta_query' => array(
+			array(
+				'key' => 'featuredArticle',
+				'value' => 'True',
+				'compare' => '='
+				),
+			),
+		'post_type' => array( 'post' , 'bibliotech'),
+		'post_status' => 'publish',
+		'posts_per_page' => 2,
+		'orderby' => 'rand',
+		'ignore_sticky_posts' => 1
+	);
+	$items = get_posts( $args );
 
-    return $items;
+	return $items;
 }
 
 function QueryPoolOne() {
-    // This builds a recordset for one post/bibliotech and one spotlight article
+	// This builds a recordset for one post/bibliotech and one spotlight article
 
-    // Start by getting post/bibliotech
-    $args = array(
-        'meta_query' => array(
-            array(
-                'key' => 'featuredArticle',
-                'value' => 'True',
-                'compare' => '='
-                ),
-            ),
-        'post_type' => array( 'post' , 'bibliotech'),
-        'post_status' => 'publish',
-        'posts_per_page' => 1,
-        'orderby' => 'rand',
-        'ignore_sticky_posts' => 1
-    );
-    $first = get_posts( $args );
+	// Start by getting post/bibliotech
+	$args = array(
+		'meta_query' => array(
+			array(
+				'key' => 'featuredArticle',
+				'value' => 'True',
+				'compare' => '='
+				),
+			),
+		'post_type' => array( 'post' , 'bibliotech'),
+		'post_status' => 'publish',
+		'posts_per_page' => 1,
+		'orderby' => 'rand',
+		'ignore_sticky_posts' => 1
+	);
+	$first = get_posts( $args );
 
-    // Then get the spotlight
-    $args = array(
-        'meta_query' => array(
-            array(
-                'key' => 'featuredArticle',
-                'value' => 'True',
-                'compare' => '='
-                ),
-            ),
-        'post_type' => array( 'spotlights'),
-        'post_status' => 'publish',
-        'posts_per_page' => 1,
-        'orderby' => 'rand',
-        'ignore_sticky_posts' => 1
-    );
-    $second = get_posts( $args );
+	// Then get the spotlight
+	$args = array(
+		'meta_query' => array(
+			array(
+				'key' => 'featuredArticle',
+				'value' => 'True',
+				'compare' => '='
+				),
+			),
+		'post_type' => array( 'spotlights'),
+		'post_status' => 'publish',
+		'posts_per_page' => 1,
+		'orderby' => 'rand',
+		'ignore_sticky_posts' => 1
+	);
+	$second = get_posts( $args );
 
-    // Merge the two
-    $items = array_merge($first,$second);
+	// Merge the two
+	$items = array_merge($first,$second);
 
-    return $items;
+	return $items;
 }
 
 function RenderPool($items) {
-    // This takes an input recordset of news items and renders it as HTML
+	// This takes an input recordset of news items and renders it as HTML
 
-    foreach($items as $item) {
-        $custom = get_post_custom($item->ID);
+	foreach($items as $item) {
+		$custom = get_post_custom($item->ID);
 
-        // URL
-        if($item->post_type === "post") {
-            $url = get_permalink($item->ID);
-        } elseif($item->post_type === "bibliotech") {
-            $url = str_replace('/news/','/news/bibliotech/',get_permalink($item->ID));
-        } elseif($item->post_type === "spotlights") {
-            $url = $custom["external_link"][0];
-        } else {
-            $url = '';
-        }
+		// URL
+		if($item->post_type === "post") {
+			$url = get_permalink($item->ID);
+		} elseif($item->post_type === "bibliotech") {
+			$url = str_replace('/news/','/news/bibliotech/',get_permalink($item->ID));
+		} elseif($item->post_type === "spotlights") {
+			$url = $custom["external_link"][0];
+		} else {
+			$url = '';
+		}
 
-        // Label
-        $label = '<div class="category-post">';
-        if($item->post_type === "post") {
-            if($item->is_event[0] === "1") {
-                $label .= "Event";
-            } else {
-                $label .= "News";
-            }
-        } else {
-            if($item->post_type === "spotlights") {
-                if($custom["feature_type"][0] === "fact" || $custom["feature_type"][0] === "tip") {
-                    $label .= '<div class="info"></div>' . $custom["feature_type"][0];
-                } else {
-                    $label .= '<div class="or_star-25"></div>Featured ' . $custom["feature_type"][0];
-                }
-            } elseif($item->post_type === "bibliotech") {
-                $label .= "Bibliotech";
-            } else {
-                $label .= "Other";
-            }
-        }
-        $label .= '</div>';
+		// Label
+		$label = '<div class="category-post">';
+		if($item->post_type === "post") {
+			if($item->is_event[0] === "1") {
+				$label .= "Event";
+			} else {
+				$label .= "News";
+			}
+		} else {
+			if($item->post_type === "spotlights") {
+				if($custom["feature_type"][0] === "fact" || $custom["feature_type"][0] === "tip") {
+					$label .= '<div class="info"></div>' . $custom["feature_type"][0];
+				} else {
+					$label .= '<div class="or_star-25"></div>Featured ' . $custom["feature_type"][0];
+				}
+			} elseif($item->post_type === "bibliotech") {
+				$label .= "Bibliotech";
+			} else {
+				$label .= "Other";
+			}
+		}
+		$label .= '</div>';
 
-        // Headline
-        if($custom["homepage_post_title"][0]) {
-            $headline = '<h3 class="title-post">' . $custom["homepage_post_title"][0] . '</h3>';
-        } else {
-            $headline = '<h3 class="title-post">' . $item->post_title . '</h3>';
-        }
+		// Headline
+		if($custom["homepage_post_title"][0]) {
+			$headline = '<h3 class="title-post">' . $custom["homepage_post_title"][0] . '</h3>';
+		} else {
+			$headline = '<h3 class="title-post">' . $item->post_title . '</h3>';
+		}
 
-        // event date, if applicable
-        $eventDate = "";
-        if($item->post_type === "post" && array_key_exists('is_event', $custom)) {
-            if($custom["is_event"][0] === "1") {
-                $eventDate = DateTime::createFromFormat('Ymd',$custom["event_date"][0]);
-                $eventDate = '<div class="date-event"><img src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px"><span class="event">' . date_format($eventDate,'F j') . '</span>';
-                if($custom["event_start_time"][0]!= '') {
-                    $eventDate = $eventDate . '<span class="time-event"> ' . $custom["event_start_time"][0];
-                };
-                if($custom["event_end_time"][0] != '') {
-                    $eventDate = $eventDate . " - " . $custom["event_end_time"][0];
-                };
-                if($custom["event_start_time"][0] != '') {
-                    $eventDate = $eventDate . '</span>';
-                };
-                $eventDate = $eventDate . "</div>";
-            }
-        }
+		// event date, if applicable
+		$eventDate = "";
+		if($item->post_type === "post" && array_key_exists('is_event', $custom)) {
+			if($custom["is_event"][0] === "1") {
+				$eventDate = DateTime::createFromFormat('Ymd',$custom["event_date"][0]);
+				$eventDate = '<div class="date-event"><img src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px"><span class="event">' . date_format($eventDate,'F j') . '</span>';
+				if($custom["event_start_time"][0]!= '') {
+					$eventDate = $eventDate . '<span class="time-event"> ' . $custom["event_start_time"][0];
+				};
+				if($custom["event_end_time"][0] != '') {
+					$eventDate = $eventDate . " - " . $custom["event_end_time"][0];
+				};
+				if($custom["event_start_time"][0] != '') {
+					$eventDate = $eventDate . '</span>';
+				};
+				$eventDate = $eventDate . "</div>";
+			}
+		}
 
-        // Highlight image
-        $imageElement = "";
-        if($item->post_type === "post" || $item->post_type === "bibliotech") {
-            if($custom["homeImg"][0] != "") {
-                $image = json_decode($custom["homeImg"][0]);
-                // We use "original" even though this is already cropped to avoid cropping again
-                $imageURL = wp_get_attachment_image_src( $image->cropped_image, 'original');
-                $imageURL = str_replace('/wp-content/uploads/','/news/files/',$imageURL[0]);
-                $imageElement = '<div class="image" style="background-image: url(' . $imageURL . ')"></div>';
-            }
-        }
+		// Highlight image
+		$imageElement = "";
+		if($item->post_type === "post" || $item->post_type === "bibliotech") {
+			if($custom["homeImg"][0] != "") {
+				$image = json_decode($custom["homeImg"][0]);
+				// We use "original" even though this is already cropped to avoid cropping again
+				$imageURL = wp_get_attachment_image_src( $image->cropped_image, 'original');
+				$imageURL = str_replace('/wp-content/uploads/','/news/files/',$imageURL[0]);
+				$imageElement = '<div class="image" style="background-image: url(' . $imageURL . ')"></div>';
+			}
+		}
 
-        echo '<a class="post--full-bleed no-underline flex-container" href="' . $url . '">';
-        echo '<div class="excerpt-news">';
-        echo $label;
-        echo $headline;
-        echo $eventDate;
-        echo '</div>';
-        echo $imageElement;
-        echo '</a>';
-    }
+		echo '<a class="post--full-bleed no-underline flex-container" href="' . $url . '">';
+		echo '<div class="excerpt-news">';
+		echo $label;
+		echo $headline;
+		echo $eventDate;
+		echo '</div>';
+		echo $imageElement;
+		echo '</a>';
+	}
 
 }
 
 function RetrievePool() {
-    // This characterizes the pool of eligible articles, and then calls the
-    // relevant query builder
+	// This characterizes the pool of eligible articles, and then calls the
+	// relevant query builder
 
-    // Get all eligible articles
-    $args = array(
-        'meta_query' => array(
-            array(
-                'key' => 'featuredArticle',
-                'value' => 'True',
-                'compare' => '='
-            ),
-        ),
-        'post_type' => array( 'post' , 'bibliotech' , 'spotlights' ),
-        'post_status' => 'publish',
-        'posts_per_page' => 99,
-        'orderby' => 'rand',
-        'ignore_sticky_posts' => 1
-    );
-    $items = get_posts( $args );
+	// Get all eligible articles
+	$args = array(
+		'meta_query' => array(
+			array(
+				'key' => 'featuredArticle',
+				'value' => 'True',
+				'compare' => '='
+			),
+		),
+		'post_type' => array( 'post' , 'bibliotech' , 'spotlights' ),
+		'post_status' => 'publish',
+		'posts_per_page' => 99,
+		'orderby' => 'rand',
+		'ignore_sticky_posts' => 1
+	);
+	$items = get_posts( $args );
 
-    return $items;
+	return $items;
 
 }
 
 function SummarizePool($items) {
-    // This takes the pool of all eligible news items, determines how many of
-    // each type exist, and determines what type of query is needed to
-    // populate the front page.
+	// This takes the pool of all eligible news items, determines how many of
+	// each type exist, and determines what type of query is needed to
+	// populate the front page.
 
-    // Summarize article list
-    $summary = array(
-        'news' => 0,
-        'spotlights' => 0,
-        'other' => 0,
-        'total' => 0,
-    );
-    foreach($items as $item) {
-        if($item->post_type === 'post' || $item->post_type === 'bibliotech') {
-            $summary["news"]++;
-        } elseif($item->post_type === 'spotlights') {
-            $summary["spotlights"]++;
-        } else {
-            $summary["other"]++;
-        };
-        $summary["total"]++;
-    }
+	// Summarize article list
+	$summary = array(
+		'news' => 0,
+		'spotlights' => 0,
+		'other' => 0,
+		'total' => 0,
+	);
+	foreach($items as $item) {
+		if($item->post_type === 'post' || $item->post_type === 'bibliotech') {
+			$summary["news"]++;
+		} elseif($item->post_type === 'spotlights') {
+			$summary["spotlights"]++;
+		} else {
+			$summary["other"]++;
+		};
+		$summary["total"]++;
+	}
 
-    // Determine query type based on summary results
-    if($summary["news"] === 1) {
-        // Only one eligible news item - so we set type to one
-        $type = "one";
-    } elseif($summary["spotlights"] === 0) {
-        // No eligible spotlights - so we show two news items
-        $type = "two";
-    } else {
-        // More than one news item - so we flip a coin for type
-        if (mt_rand(0,1)) {
-            $type = "two";
-        } else {
-            $type = "one";
-        }
-    }
+	// Determine query type based on summary results
+	if($summary["news"] === 1) {
+		// Only one eligible news item - so we set type to one
+		$type = "one";
+	} elseif($summary["spotlights"] === 0) {
+		// No eligible spotlights - so we show two news items
+		$type = "two";
+	} else {
+		// More than one news item - so we flip a coin for type
+		if (mt_rand(0,1)) {
+			$type = "two";
+		} else {
+			$type = "one";
+		}
+	}
 
-    return $type;
+	return $type;
 }

--- a/lib/news.php
+++ b/lib/news.php
@@ -37,13 +37,13 @@ function LoadNews() {
 
 	$pool = RetrievePool();
 
-	if(count($pool) != 2) {
+	if ( count($pool) != 2 ) {
 		// If there are anything other than two items in the pool, then we
 		// summarize the pool and determine query type
 		$queryType = SummarizePool($pool);
 
 		// Build the appropriate item pool
-		if($queryType === 'two') {
+		if ( $queryType === 'two' ) {
 			$pool = QueryPoolTwo();
 		} else {
 			$pool = QueryPoolOne();
@@ -121,18 +121,18 @@ function QueryPoolOne() {
 	return $items;
 }
 
-function RenderPool($items) {
+function RenderPool( $items ) {
 	// This takes an input recordset of news items and renders it as HTML
 
-	foreach($items as $item) {
+	foreach ( $items as $item ) {
 		$custom = get_post_custom($item->ID);
 
 		// URL
-		if($item->post_type === "post") {
+		if ( $item->post_type === "post" ) {
 			$url = get_permalink($item->ID);
-		} elseif($item->post_type === "bibliotech") {
+		} elseif ( $item->post_type === "bibliotech" ) {
 			$url = str_replace('/news/','/news/bibliotech/',get_permalink($item->ID));
-		} elseif($item->post_type === "spotlights") {
+		} elseif ( $item->post_type === "spotlights" ) {
 			$url = $custom["external_link"][0];
 		} else {
 			$url = '';
@@ -140,20 +140,20 @@ function RenderPool($items) {
 
 		// Label
 		$label = '<div class="category-post">';
-		if($item->post_type === "post") {
-			if($item->is_event[0] === "1") {
+		if ( $item->post_type === "post" ) {
+			if ( $item->is_event[0] === "1" ) {
 				$label .= "Event";
 			} else {
 				$label .= "News";
 			}
 		} else {
-			if($item->post_type === "spotlights") {
-				if($custom["feature_type"][0] === "fact" || $custom["feature_type"][0] === "tip") {
+			if ( $item->post_type === "spotlights" ) {
+				if ( $custom["feature_type"][0] === "fact" || $custom["feature_type"][0] === "tip" ) {
 					$label .= '<div class="info"></div>' . $custom["feature_type"][0];
 				} else {
 					$label .= '<div class="or_star-25"></div>Featured ' . $custom["feature_type"][0];
 				}
-			} elseif($item->post_type === "bibliotech") {
+			} elseif ( $item->post_type === "bibliotech" ) {
 				$label .= "Bibliotech";
 			} else {
 				$label .= "Other";
@@ -162,7 +162,7 @@ function RenderPool($items) {
 		$label .= '</div>';
 
 		// Headline
-		if($custom["homepage_post_title"][0]) {
+		if ( $custom["homepage_post_title"][0] ) {
 			$headline = '<h3 class="title-post">' . $custom["homepage_post_title"][0] . '</h3>';
 		} else {
 			$headline = '<h3 class="title-post">' . $item->post_title . '</h3>';
@@ -170,17 +170,17 @@ function RenderPool($items) {
 
 		// event date, if applicable
 		$eventDate = "";
-		if($item->post_type === "post" && array_key_exists('is_event', $custom)) {
-			if($custom["is_event"][0] === "1") {
+		if ( $item->post_type === "post" && array_key_exists('is_event', $custom) ) {
+			if ( $custom["is_event"][0] === "1" ) {
 				$eventDate = DateTime::createFromFormat('Ymd',$custom["event_date"][0]);
 				$eventDate = '<div class="date-event"><img src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px"><span class="event">' . date_format($eventDate,'F j') . '</span>';
-				if($custom["event_start_time"][0]!= '') {
+				if ( $custom["event_start_time"][0]!= '' ) {
 					$eventDate = $eventDate . '<span class="time-event"> ' . $custom["event_start_time"][0];
 				};
-				if($custom["event_end_time"][0] != '') {
+				if ( $custom["event_end_time"][0] != '' ) {
 					$eventDate = $eventDate . " - " . $custom["event_end_time"][0];
 				};
-				if($custom["event_start_time"][0] != '') {
+				if ( $custom["event_start_time"][0] != '' ) {
 					$eventDate = $eventDate . '</span>';
 				};
 				$eventDate = $eventDate . "</div>";
@@ -189,8 +189,8 @@ function RenderPool($items) {
 
 		// Highlight image
 		$imageElement = "";
-		if($item->post_type === "post" || $item->post_type === "bibliotech") {
-			if($custom["homeImg"][0] != "") {
+		if ( $item->post_type === "post" || $item->post_type === "bibliotech" ) {
+			if ( $custom["homeImg"][0] != "" ) {
 				$image = json_decode($custom["homeImg"][0]);
 				// We use "original" even though this is already cropped to avoid cropping again
 				$imageURL = wp_get_attachment_image_src( $image->cropped_image, 'original');
@@ -236,7 +236,7 @@ function RetrievePool() {
 
 }
 
-function SummarizePool($items) {
+function SummarizePool( $items ) {
 	// This takes the pool of all eligible news items, determines how many of
 	// each type exist, and determines what type of query is needed to
 	// populate the front page.
@@ -248,10 +248,10 @@ function SummarizePool($items) {
 		'other' => 0,
 		'total' => 0,
 	);
-	foreach($items as $item) {
-		if($item->post_type === 'post' || $item->post_type === 'bibliotech') {
+	foreach ( $items as $item ) {
+		if ( $item->post_type === 'post' || $item->post_type === 'bibliotech' ) {
 			$summary["news"]++;
-		} elseif($item->post_type === 'spotlights') {
+		} elseif ( $item->post_type === 'spotlights' ) {
 			$summary["spotlights"]++;
 		} else {
 			$summary["other"]++;
@@ -260,15 +260,15 @@ function SummarizePool($items) {
 	}
 
 	// Determine query type based on summary results
-	if($summary["news"] === 1) {
+	if ( $summary["news"] === 1 ) {
 		// Only one eligible news item - so we set type to one
 		$type = "one";
-	} elseif($summary["spotlights"] === 0) {
+	} elseif ( $summary["spotlights"] === 0 ) {
 		// No eligible spotlights - so we show two news items
 		$type = "two";
 	} else {
 		// More than one news item - so we flip a coin for type
-		if (mt_rand(0,1)) {
+		if ( mt_rand(0,1) ) {
 			$type = "two";
 		} else {
 			$type = "one";

--- a/lib/news.php
+++ b/lib/news.php
@@ -174,7 +174,7 @@ function RenderPool( $items ) {
 			if ( $custom["is_event"][0] === "1" ) {
 				$eventDate = DateTime::createFromFormat('Ymd',$custom["event_date"][0]);
 				$eventDate = '<div class="date-event"><img src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px"><span class="event">' . date_format($eventDate,'F j') . '</span>';
-				if ( $custom["event_start_time"][0]!= '' ) {
+				if ( $custom["event_start_time"][0] != '' ) {
 					$eventDate = $eventDate . '<span class="time-event"> ' . $custom["event_start_time"][0];
 				};
 				if ( $custom["event_end_time"][0] != '' ) {

--- a/page-featured-news.php
+++ b/page-featured-news.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Template Name: Featured News Article List
  *
@@ -29,7 +29,7 @@
 			var_dump($foo);
 			echo '</pre>';
 			*/
-			
+
 			$args = array(
 				'meta_query' => array(
 					array(
@@ -116,7 +116,7 @@
 					}
 					echo  		'</div>';
 					if($post->post_type === "post" && $post->is_event[0] === "1") {
-						echo 	'<div class="datetime">' . $eventDate . '</div>';						
+						echo 	'<div class="datetime">' . $eventDate . '</div>';
 					}
 					echo 		'<h3 class="title-post">';
 
@@ -156,7 +156,7 @@
 			</div><!-- end div.news-events -->
 		</div><!-- end div.col-2 -->
 
-<?php 
+<?php
 	get_footer();
 ?>
 <script>

--- a/page-featured-news.php
+++ b/page-featured-news.php
@@ -48,7 +48,7 @@
 			$the_stories = null;
 			$the_stories = new WP_Query($args);
 
-			if( $the_stories->have_posts() ) {
+			if ( $the_stories->have_posts() ) {
 				while ( $the_stories->have_posts() ) : $the_stories->the_post();
 					// setup_postdata($post);
 					$custom = get_post_custom();
@@ -61,8 +61,8 @@
 
 					// Highlight image - use 17616 for debugging
 					$imageTag = "";
-					if($post->post_type === "post" || $post->post_type === "bibliotech") {
-						if($custom["homeImg"][0] != "") {
+					if ( $post->post_type === "post" || $post->post_type === "bibliotech" ) {
+						if ( $custom["homeImg"][0] != "" ) {
 							$image = json_decode($custom["homeImg"][0]);
 							$imageURL = wp_get_attachment_image_src( $image->cropped_image, 'original');
 							$imageURL = str_replace('/wp-content/uploads/','/news/files/',$imageURL[0]);
@@ -75,16 +75,16 @@
 					echo '">';
 
 					// card label
-					if($post->post_type === "post") {
-						if($post->is_event[0] === "1") {
+					if ( $post->post_type === "post" ) {
+						if ( $post->is_event[0] === "1" ) {
 							$label = "Event";
 						} else {
 							$label = "News";
 						}
 					} else {
-						if($post->post_type === "spotlights") {
+						if ( $post->post_type === "spotlights" ) {
 							$label = $custom["feature_type"][0];
-						} elseif($post->post_type === "bibliotech") {
+						} elseif ( $post->post_type === "bibliotech" ) {
 							$label = "Bibliotech";
 						} else {
 							$label = "Other";
@@ -92,13 +92,13 @@
 					}
 
 					// card date
-					if($post->post_type === "post" && $post->is_event[0] === "1") {
+					if ( $post->post_type === "post" && $post->is_event[0] === "1" ) {
 						$eventDate = DateTime::createFromFormat('Ymd',$post->event_date);
 						$eventDate = '<span class="date">' . date_format($eventDate,'F j') . '</span>';
-						if($post->event_start_time != '') {
+						if ( $post->event_start_time != '' ) {
 							$eventDate = $eventDate . " " . $post->event_start_time;
 						};
-						if($post->event_end_time != '') {
+						if ( $post->event_end_time != '' ) {
 							$eventDate = $eventDate . " - " . $post->event_end_time;
 						};
 					}
@@ -107,20 +107,20 @@
 					echo        '<div class="category-post">' . $label . '</div>';
 					// echo        '<div class="category-post">' . $url . '</div>';
 					echo        '<div class="href">';
-					if($post->post_type === "post" || $post->post_type === "bibliotech") {
+					if ( $post->post_type === "post" || $post->post_type === "bibliotech" ) {
 						the_permalink();
-					} elseif($post->post_type === "spotlights") {
+					} elseif ( $post->post_type === "spotlights" ) {
 						echo $custom["external_link"][0];
 					} else {
 
 					}
 					echo  		'</div>';
-					if($post->post_type === "post" && $post->is_event[0] === "1") {
+					if ( $post->post_type === "post" && $post->is_event[0] === "1" ) {
 						echo 	'<div class="datetime">' . $eventDate . '</div>';
 					}
 					echo 		'<h3 class="title-post">';
 
-					if($custom["homepage_post_title"][0]) {
+					if ( $custom["homepage_post_title"][0] ) {
 						echo $custom["homepage_post_title"][0];
 					} else {
 						the_title();

--- a/page-getit.php
+++ b/page-getit.php
@@ -8,7 +8,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Template Name: Home Page
  *
@@ -96,6 +96,6 @@
 		</div><!-- end div.col-2 -->
 	</div><!-- end div.content-main -->
 
-<?php 
+<?php
 	get_footer();
 ?>

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -14,7 +14,7 @@
 
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
-if (!$_GET["d"]) {
+if ( !$_GET["d"] ) {
 	$inDate = "Now";
 } else {
 	$inDate = $_GET["d"];
@@ -55,7 +55,7 @@ $now = strtotime($dtTodayYear."W".$dtTodayWeek.$dtTodayWeekday);
 
 $wk = date("W", $dt);
 
-if ($wk == "01" && $dtMo == "12") {
+if ( $wk == "01" && $dtMo == "12" ) {
 	$dtYear++;
 }
 
@@ -163,43 +163,43 @@ tr:nth-child(even) td {
       <th class="name">Locations</th>
         <?php $next = ""; ?>
         <?php $i = 0; $day = $arDays[$i]; ?>
-        <th class="fullDay firstDisplay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay firstDisplay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 1; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 2; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 3; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 4; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 5; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 6; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
@@ -227,7 +227,7 @@ $mapPage = "/locations/#!";
         <tr data-location="<?php the_title(); ?>">
           <td width="260" class="name"><div class="nameHolder">
               <h3> <a href="<?php $post_object = get_field('display_page');
-			  if( $post_object ):
+			  if ( $post_object ) :
 		  // dont even ask why
 			$post = $post_object;
 			setup_postdata( $post );
@@ -242,10 +242,10 @@ $mapPage = "/locations/#!";
               <a class="map" href="<?php echo $mapPage.$slug; ?>">Map:&nbsp;
               <?php  the_field('building', $locationId); ?>
               </a>
-              <?php if(get_field('study_24', $locationId)){ ?>
+              <?php if ( get_field('study_24', $locationId) ) { ?>
               <span class="hidden">|</span> <a class="space247" href="/study/24x7/" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
               <?php } ?>
-              <?php if(get_field('alert_title', $locationId)){ ?>
+              <?php if ( get_field('alert_title', $locationId) ) { ?>
               <div class="libraryAlert"> <i class="icon-exclamation-sign"></i>
 	              <div class="alertText">
               <div class="la-title"><?php the_field('alert_title', $locationId); ?></div>
@@ -254,11 +254,11 @@ $mapPage = "/locations/#!";
               </div>
               <?php } ?>
             </div></td>
-          <?php for($i=0;$i<=6;$i++) { ?>
+          <?php for ( $i=0;$i<=6;$i++ ) { ?>
           <?php
 	  $curDay = $arDays[$i];
 
-	  if ($curDay == $now) {
+	  if ( $curDay == $now ) {
 		$class = "cur";
 		$next = "curAfter";
 	  } else {
@@ -276,43 +276,43 @@ $mapPage = "/locations/#!";
       <th class="name">More Locations</th>
         <?php $next = ""; ?>
         <?php $i = 0; $day = $arDays[$i]; ?>
-        <th class="fullDay firstDisplay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay firstDisplay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 1; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 2; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 3; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 4; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 5; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 6; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ($now == $day) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
@@ -367,10 +367,10 @@ $pageLink = get_permalink($pageID);
             <a class="map" href="<?php echo $mapPage.$slug; ?>">Map:&nbsp;
             <?php  the_field('building', $locationId); ?>
             </a>
-            <?php if(get_field('study_location', $locationId)){ ?>
+            <?php if ( get_field('study_location', $locationId) ) { ?>
             <a class="space247" href="/study/24x7/" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7"> | Study 24/7</a>
             <?php } ?>
-              <?php if(get_field('alert_title', $locationId)){ ?>
+              <?php if ( get_field('alert_title', $locationId) ) { ?>
               <div class="libraryAlert"> <i class="icon-exclamation-sign"></i>
 	              <div class="alertText">
               <div class="la-title"><?php the_field('alert_title', $locationId); ?></div>
@@ -379,11 +379,11 @@ $pageLink = get_permalink($pageID);
               </div>
               <?php } ?>
           </div></td>
-        <?php for($i=0;$i<=6;$i++) { ?>
+        <?php for ( $i=0;$i<=6;$i++ ) { ?>
         <?php
 $curDay = $arDays[$i];
 
-if ($curDay == $now) {
+if ( $curDay == $now ) {
 $class = "cur";
 $next = "curAfter";
 } else {

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -14,7 +14,7 @@
 
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
-if ( !$_GET["d"] ) {
+if ( ! $_GET["d"] ) {
 	$inDate = "Now";
 } else {
 	$inDate = $_GET["d"];
@@ -38,7 +38,7 @@ $dtWeekday = date("N", $dt);
 <link rel='stylesheet' id=''  href='/wp-content/themes/libraries/css/mobile.css' type='text/css' media='all' />
 <script src="<?php echo get_template_directory_uri(); ?>/libs/datepicker/glDatePicker.min.js"></script>
 <script>
-  todayDate = new Date(<?php echo $dtYear; ?>,<?php echo ($dtMo-1); ?>,<?php echo $dtDay; ?>);
+  todayDate = new Date(<?php echo $dtYear; ?>,<?php echo ($dtMo -1); ?>,<?php echo $dtDay; ?>);
 </script>
 <?php
 
@@ -163,43 +163,43 @@ tr:nth-child(even) td {
       <th class="name">Locations</th>
         <?php $next = ""; ?>
         <?php $i = 0; $day = $arDays[$i]; ?>
-        <th class="fullDay firstDisplay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay firstDisplay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 1; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 2; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 3; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 4; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 5; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 6; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
@@ -254,7 +254,7 @@ $mapPage = "/locations/#!";
               </div>
               <?php } ?>
             </div></td>
-          <?php for ( $i=0;$i<=6;$i++ ) { ?>
+          <?php for ( $i = 0;$i <= 6;$i++ ) { ?>
           <?php
 	  $curDay = $arDays[$i];
 
@@ -276,43 +276,43 @@ $mapPage = "/locations/#!";
       <th class="name">More Locations</th>
         <?php $next = ""; ?>
         <?php $i = 0; $day = $arDays[$i]; ?>
-        <th class="fullDay firstDisplay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay firstDisplay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 1; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 2; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 3; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 4; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 5; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
           </span> </th>
         <?php $i = 6; $day = $arDays[$i]; ?>
-        <th class="fullDay <?php echo $next; $next=""; if ( $now == $day ) { echo "cur"; $next="curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
+        <th class="fullDay <?php echo $next; $next = ""; if ( $now == $day ) { echo "cur"; $next = "curAfter";} ?>"> <span class="fullDay"><?php echo date("l", $day); ?>
           <div class='date'><?php echo date($dfDow, $day);?></div>
           </span> <span class="mobileDay"><?php echo date("D", $day); ?>
           <div class='date'><?php echo date($dfDowMobile, $day);?></div>
@@ -379,7 +379,7 @@ $pageLink = get_permalink($pageID);
               </div>
               <?php } ?>
           </div></td>
-        <?php for ( $i=0;$i<=6;$i++ ) { ?>
+        <?php for ( $i = 0;$i <= 6;$i++ ) { ?>
         <?php
 $curDay = $arDays[$i];
 

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -15,9 +15,9 @@
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 if (!$_GET["d"]) {
-  $inDate = "Now";
+	$inDate = "Now";
 } else {
-  $inDate = $_GET["d"];
+	$inDate = $_GET["d"];
 }
 
 get_header();
@@ -56,7 +56,7 @@ $now = strtotime($dtTodayYear."W".$dtTodayWeek.$dtTodayWeekday);
 $wk = date("W", $dt);
 
 if ($wk == "01" && $dtMo == "12") {
-  $dtYear++;
+	$dtYear++;
 }
 
 $mon = strtotime($dtISOYear."W".$wk."1");
@@ -90,7 +90,7 @@ $thisWeek = date("Y-n-j");
 $alertTitle = cf("alert_title");
 $alertContent = cf("alert_content");
 
- ?>
+	?>
 
 <div id="stage" class="hoursHeader inner hours group" role="main">
   <div class="title-page flex-container">
@@ -101,9 +101,9 @@ $alertContent = cf("alert_content");
     </div>
     <div class="middleAlert">
       <?php
-    if ( have_posts() ) :
-  while ( have_posts() ) : the_post();
-          the_content(); ?>
+	if ( have_posts() ) :
+	while ( have_posts() ) : the_post();
+		  the_content(); ?>
       <?php  endwhile;  endif; wp_reset_query();  ?>
     </div>
     <div class="wrap-cal-hours hidden-phone">
@@ -227,11 +227,11 @@ $mapPage = "/locations/#!";
         <tr data-location="<?php the_title(); ?>">
           <td width="260" class="name"><div class="nameHolder">
               <h3> <a href="<?php $post_object = get_field('display_page');
-              if( $post_object ):
-          // dont even ask why
-            $post = $post_object;
-            setup_postdata( $post );
-            ?>
+			  if( $post_object ):
+		  // dont even ask why
+			$post = $post_object;
+			setup_postdata( $post );
+			?>
             <?php the_permalink(); ?>">
                 <?php the_title(); ?>
                 </a></h3>
@@ -256,16 +256,16 @@ $mapPage = "/locations/#!";
             </div></td>
           <?php for($i=0;$i<=6;$i++) { ?>
           <?php
-      $curDay = $arDays[$i];
+	  $curDay = $arDays[$i];
 
-      if ($curDay == $now) {
-        $class = "cur";
-        $next = "curAfter";
-      } else {
-        $class = $next;
-        $next = "";
-      }
-    ?>
+	  if ($curDay == $now) {
+		$class = "cur";
+		$next = "curAfter";
+	  } else {
+		$class = $next;
+		$next = "";
+	  }
+	?>
           <td data-day="<?php echo $i; ?>" class="<?php echo $class.$firstDay; ?>" data-foo="bar"><span class="hidden-non-mobile date-label"><?php echo date("D", $curDay)."<br/>".date("n/j", $curDay); ?></span></td>
           <?php } ?>
         </tr>
@@ -330,15 +330,15 @@ $args = array(
 'orderby' => 'name',
 'order' => 'ASC',
 //excludes DIRC and Stata
-  'meta_query' => array(
-    'relation' => 'AND',
-    array(
-      'key' => 'no_hours',
-      'value' => 0,
-      'compare' => '='
-      ),
+	'meta_query' => array(
+	'relation' => 'AND',
+	array(
+	  'key' => 'no_hours',
+	  'value' => 0,
+	  'compare' => '='
+	  ),
 
-    )
+	)
 );
 $libraryList2 = new WP_Query( $args );?>
         <?php while ( $libraryList2->have_posts() ) : $libraryList2->the_post();
@@ -355,7 +355,7 @@ $mapPage = "/locations/#!";
 $displayPage = get_field("display_page");
 $pageID = $displayPage->ID;
 $pageLink = get_permalink($pageID);
-              ?>
+			  ?>
 <h3><a href="<?php echo $pageLink; ?>"><?php the_title(); ?></a></h3>
   
               

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -57,7 +57,7 @@ $wk = date("W", $dt);
 
 if ($wk == "01" && $dtMo == "12") {
   $dtYear++;
-} 
+}
 
 $mon = strtotime($dtISOYear."W".$wk."1");
 $tue = strtotime($dtISOYear."W".$wk."2");
@@ -102,7 +102,7 @@ $alertContent = cf("alert_content");
     <div class="middleAlert">
       <?php
     if ( have_posts() ) :
-  while ( have_posts() ) : the_post(); 
+  while ( have_posts() ) : the_post();
           the_content(); ?>
       <?php  endwhile;  endif; wp_reset_query();  ?>
     </div>
@@ -216,9 +216,9 @@ $args = array(
 /*'orderby' => 'menu_order',*/
 'orderby' => 'name',
 'order' => 'ASC'
-);              
+);
 $libraryList = new WP_Query( $args );?>
-        <?php while ( $libraryList->have_posts() ) : $libraryList->the_post(); 
+        <?php while ( $libraryList->have_posts() ) : $libraryList->the_post();
 $locationId = get_the_ID();
 $slug = $post->post_name;
 $mapPage = "/locations/#!";
@@ -227,10 +227,10 @@ $mapPage = "/locations/#!";
         <tr data-location="<?php the_title(); ?>">
           <td width="260" class="name"><div class="nameHolder">
               <h3> <a href="<?php $post_object = get_field('display_page');
-              if( $post_object ): 
+              if( $post_object ):
           // dont even ask why
             $post = $post_object;
-            setup_postdata( $post ); 
+            setup_postdata( $post );
             ?>
             <?php the_permalink(); ?>">
                 <?php the_title(); ?>
@@ -257,7 +257,7 @@ $mapPage = "/locations/#!";
           <?php for($i=0;$i<=6;$i++) { ?>
           <?php
       $curDay = $arDays[$i];
-      
+
       if ($curDay == $now) {
         $class = "cur";
         $next = "curAfter";
@@ -337,11 +337,11 @@ $args = array(
       'value' => 0,
       'compare' => '='
       ),
-    
-    ) 
-);              
+
+    )
+);
 $libraryList2 = new WP_Query( $args );?>
-        <?php while ( $libraryList2->have_posts() ) : $libraryList2->the_post(); 
+        <?php while ( $libraryList2->have_posts() ) : $libraryList2->the_post();
 $locationId = get_the_ID();
 $slug = $post->post_name;
 $mapPage = "/locations/#!";
@@ -351,7 +351,7 @@ $mapPage = "/locations/#!";
         <td width="260"  class="name"><div class="nameHolder">
           
     
-<?php 
+<?php
 $displayPage = get_field("display_page");
 $pageID = $displayPage->ID;
 $pageLink = get_permalink($pageID);

--- a/page-location.php
+++ b/page-location.php
@@ -11,7 +11,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;
@@ -23,16 +23,16 @@ get_header(); ?>
 			&raquo; <?php showBreadTitle(); ?>
 		</div>
 
-		<?php 
+		<?php
 			$objs = get_field("page_location");
-			
+
 			$args = array(
 				'p' => $objs->ID,
 				'post_type' => 'any'
 			);
-			
+
 			$locPosts = new WP_Query($args);
-			
+
 		?>
 		
 		<?php while ( $locPosts->have_posts() ) : $locPosts->the_post(); ?>

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -11,7 +11,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 
@@ -38,57 +38,57 @@ get_header(); ?>
 			<div id="locationsHome">
 				<div id="mapMarkers" class="meta">
 						<?php
-							
+
 							$args = array(
 								'post_type' => 'location',
 								'posts_per_page' => -1,
 								'orderby' => 'menu_order',
 								'order' => 'ASC'
-							);							
+							);
 							$libraryList = new WP_Query( $args );
 						?>
 						<?php while ( $libraryList->have_posts() ) : $libraryList->the_post(); ?>
-						<?php 
+						<?php
 							$locationId = get_the_ID();
 							$slug = $post->post_name;
-							
+
 							$building = cf("building");
-							
+
 							$numMain = 3;
 							$arMain = array();
-							
+
 							$mapImage = get_field("map_image");
-							
-							
+
+
 							for($i=1;$i<=$numMain;$i++) {
 								$img = get_field("main_image".$i, $locationId);
 								if ($img != "")
 									$arMain[] = $img;
 							}
-							$val = $arMain[array_rand($arMain)];							
-							//$val = $arMain[0];							
-							
+							$val = $arMain[array_rand($arMain)];
+							//$val = $arMain[0];
+
 							if ($mapImage != "") {
 								// user override image;
 								$val = $mapImage;
 							}
-							
+
 							$location = get_field("building_location");
 								$coords = explode(",", $location['coordinates']);
 								$lat = $coords[0];
 								$lng = $coords[1];
 								$address = $location['address'];
-							
+
 							$name = html_entity_decode(get_the_title());
-							
+
 							$displayPage = get_field("display_page");
 							$pageID = $displayPage->ID;
 							$pageLink = get_permalink($pageID);
-							
+
 							$directionsUrl = "http://maps.google.com/maps?";
 							$directionsUrl .= "daddr=".$lat.",".$lng;
 							//$directionsUrl .= "daddr=".urlencode($address);
-							
+
 							if ($lat != "" && $lng != ""):
 						?>				
 						<div class="location">
@@ -123,7 +123,7 @@ get_header(); ?>
 				<div class="content-page col-1">
 					<ul class="locations-main flex-container">
 						<?php
-							
+
 							$args = array(
 								'post_type' => 'location',
 								'meta_key' => 'primary_location',
@@ -131,31 +131,31 @@ get_header(); ?>
 								'posts_per_page' => -1,
 								'orderby' => 'menu_order',
 								'order' => 'ASC'
-							);							
+							);
 							$libraryList = new WP_Query( $args );
 						?>
 						<?php while ( $libraryList->have_posts() ) : $libraryList->the_post(); ?>
-						<?php 
+						<?php
 							$locationId = get_the_ID();
 							$slug = $post->post_name;
-							
+
 							$subject = cf("subject");
 							$phone = cf("phone");
 							$building = cf("building");
 							$spaces = cf("group_spaces");
 							$equipment = cf("equipment");
 							$expert = cf("expert");
-							
+
 							$study24 = get_field("study_24");
 
 							$displayPage = get_field("display_page");
 							$pageID = $displayPage->ID;
 							$pageLink = get_permalink($pageID);
-							
+
 							$temp = $post;
 							$post = $temp;
-							
-							
+
+
 						?>
 							<li class="location-name">
 								<h2 class="name-location"><a href="<?php echo $pageLink ?>" class="locationLink"><?php the_title(); ?></a></h2>
@@ -182,25 +182,25 @@ get_header(); ?>
 							'posts_per_page' => -1,
 							'orderby' => 'menu_order',
 							'order' => 'ASC'
-							
-						);							
+
+						);
 						$subList = new WP_Query( $args );
 					?>					
 					<?php while ( $subList->have_posts() ) : $subList->the_post(); ?>
-					<?php 
+					<?php
 						$locationId = get_the_ID();
 						$slug = $post->post_name;
-						
+
 						$subject = cf("subject");
 						$phone = cf("phone");
 						$building = cf("building");
 						$spaces = cf("group_spaces");
 						$equipment = cf("equipment");
 						$expert = cf("expert");
-						
+
 						$temp = $post;
 						$post = $temp;
-						
+
 						$displayPage = get_field("display_page");
 						$pageID = $displayPage->ID;
 						$pageLink = get_permalink($pageID);

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -60,7 +60,7 @@ get_header(); ?>
 							$mapImage = get_field("map_image");
 
 
-							for($i=1;$i<=$numMain;$i++) {
+							for ( $i=1;$i<=$numMain;$i++ ) {
 								$img = get_field("main_image".$i, $locationId);
 								if ($img != "")
 									$arMain[] = $img;
@@ -68,7 +68,7 @@ get_header(); ?>
 							$val = $arMain[array_rand($arMain)];
 							//$val = $arMain[0];
 
-							if ($mapImage != "") {
+							if ( $mapImage != "" ) {
 								// user override image;
 								$val = $mapImage;
 							}
@@ -89,7 +89,7 @@ get_header(); ?>
 							$directionsUrl .= "daddr=".$lat.",".$lng;
 							//$directionsUrl .= "daddr=".urlencode($address);
 
-							if ($lat != "" && $lng != ""):
+							if ( $lat != "" && $lng != "" ) :
 						?>				
 						<div class="location">
 							<div class="id"><?php echo $locationId; ?></div>
@@ -100,7 +100,7 @@ get_header(); ?>
 							<div class="address"><?php echo $address; ?></div>
 							<div class="description">
 								<div class="infoContent">
-									<?php if ($val != ""): ?>
+									<?php if ( $val != "" ) : ?>
 									<div class="infoImage" style="background-image: url(<?php echo $val; ?>); background-repeat: no-repeat;"></div>
 									<?php endif; ?>
 									<div class="content">
@@ -160,11 +160,11 @@ get_header(); ?>
 							<li class="location-name">
 								<h2 class="name-location"><a href="<?php echo $pageLink ?>" class="locationLink"><?php the_title(); ?></a></h2>
 								<div class="sub"><?php echo $subject ?></div>
-								<?php if ($phone != ""): ?>
+								<?php if ( $phone != "" ) : ?>
 								<?php echo $phone ?>
 								<br/>
 								<?php endif; ?><a class="map" data-target="<?php echo $locationId; ?>" href="#!<?php echo $slug; ?>">Map: <?php echo $building ?></a>
-								<?php if ($study24 == 1): ?>
+								<?php if ( $study24 == 1 ) : ?>
 									<br/>
 									<a class="space247" href="<?php echo $gStudy24Url; ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 								<?php endif; ?>
@@ -206,12 +206,12 @@ get_header(); ?>
 						$pageLink = get_permalink($pageID);
 					?>
 						<li class="location-secondary">
-							<?php if ($slug === "stata"): ?>
+							<?php if ( $slug === "stata" ) : ?>
 							<h3 class="name-location--secondary"><?php echo the_title() ?></h3>
-							<?php else: ?>
+							<?php else : ?>
 							<h3 class="name-location--secondary"><a href="<?php echo $pageLink; ?>"><?php echo the_title() ?></a></h3>
 							<?php endif; ?>
-							<?php if ($phone != ""): ?>
+							<?php if ( $phone != "" ) : ?>
 							<?php echo $phone ?><br/>
 							<?php endif; ?>
 							<a class="map" data-target="<?php echo $locationId; ?>" href="#!<?php echo $slug; ?>">Map: <?php echo $building ?></a>

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -60,7 +60,7 @@ get_header(); ?>
 							$mapImage = get_field("map_image");
 
 
-							for ( $i=1;$i<=$numMain;$i++ ) {
+							for ( $i = 1;$i <= $numMain;$i++ ) {
 								$img = get_field("main_image".$i, $locationId);
 								if ($img != "")
 									$arMain[] = $img;

--- a/page-my-admin.php
+++ b/page-my-admin.php
@@ -42,7 +42,7 @@ get_header(); ?>
 
 	<?php
 
-		if(!current_user_can('manage_options')) {
+		if ( !current_user_can('manage_options') ) {
 			include( get_query_template( '404' ) );
 			exit();
 		}
@@ -61,9 +61,9 @@ get_header(); ?>
 			<h2>Blog IDs</h2>
 			<ul>
 			<?php
-				for ($i = 1; $i <= 30; $i++) {
+				for ( $i = 1; $i <= 30; $i++ ) {
 				$blog_details = get_blog_details($i);
-				if ($blog_details == '') {
+				if ( $blog_details == '' ) {
 					echo '<li>There is no blog '.$i.'</li>';
 				}
 				else {

--- a/page-my-admin.php
+++ b/page-my-admin.php
@@ -42,7 +42,7 @@ get_header(); ?>
 
 	<?php
 
-		if ( !current_user_can('manage_options') ) {
+		if ( ! current_user_can('manage_options') ) {
 			include( get_query_template( '404' ) );
 			exit();
 		}

--- a/page-my-admin.php
+++ b/page-my-admin.php
@@ -26,7 +26,7 @@ get_header(); ?>
 	    'meta_key' => '_wp_page_template',
 	    'meta_value' => 'page-full.php',
 	    'depth' => -1,
-      'hierarchical' => 0
+	  'hierarchical' => 0
 	);
 
 	$template_pages = get_pages($template_page_args);
@@ -62,13 +62,13 @@ get_header(); ?>
 			<ul>
 			<?php
 				for ($i = 1; $i <= 30; $i++) {
-    			$blog_details = get_blog_details($i);
-    			if ($blog_details == '') {
-    				echo '<li>There is no blog '.$i.'</li>';
-    			}
-    			else {
-    				echo '<li>Blog '.$blog_details->blog_id.' is called '.$blog_details->blogname.'.</li>';
-    			}
+				$blog_details = get_blog_details($i);
+				if ($blog_details == '') {
+					echo '<li>There is no blog '.$i.'</li>';
+				}
+				else {
+					echo '<li>Blog '.$blog_details->blog_id.' is called '.$blog_details->blogname.'.</li>';
+				}
 				}
 			?>
 			</ul>

--- a/page-my-admin.php
+++ b/page-my-admin.php
@@ -17,7 +17,7 @@ $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;
 
 
- 
+
 get_header(); ?>
 
 	<?php
@@ -30,12 +30,12 @@ get_header(); ?>
 	);
 
 	$template_pages = get_pages($template_page_args);
-	
+
 	$template_query_args = array (
 		'meta_key' => '_wp_page_template',
 		'meta_value' => 'page-full.php'
 	);
-	
+
 	$template_queries = get_pages($template_query_args);
 
 	?>

--- a/page-rss.php
+++ b/page-rss.php
@@ -7,7 +7,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;

--- a/page-search.php
+++ b/page-search.php
@@ -32,9 +32,9 @@ get_header(); ?>
 			<?php while ( have_posts() ) : the_post(); ?>
 
 			<div class="title-page">
-				<?php if ($isRoot): ?>
+				<?php if ( $isRoot ) : ?>
 				<h1><?php echo $section->post_title; ?></h1>
-				<?php else: ?>
+				<?php else : ?>
 				<h1><a href="<?php echo get_permalink($section->ID) ?>"><?php echo $section->post_title; ?></a></h1>
 				<?php endif; ?>
 			</div>

--- a/page-study-spaces.php
+++ b/page-study-spaces.php
@@ -11,7 +11,7 @@
  * @subpackage Twenty_Twelve
  * @since Twenty Twelve 1.0
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 
@@ -44,35 +44,35 @@ get_header(); ?>
 								'posts_per_page' => -1,
 								'orderby' => 'menu_order',
 								'order' => 'ASC'
-								
-							);							
+
+							);
 							$subList = new WP_Query( $args );
-							
+
 						?>					
 						<?php while ( $subList->have_posts() ) : $subList->the_post(); ?>
-						<?php 
+						<?php
 							$locationId = get_the_ID();
 							$slug = $post->post_name;
-							
+
 							$subject = get_field("subject");
 							$phone = get_field("phone");
 							$building = get_field("building");
 							$spaces = get_field("group_spaces");
 							$individual = get_field("individual_spaces");
-							
+
 							$equipment = get_field("equipment");
 							$expert = get_field("expert");
-							
+
 							$title1 = get_field("tab_1_title");
 							$subtitle1 = get_field("tab_1_subtitle");
 							$content1 = get_field("tab_1_content");
-							
+
 							$title2 = get_field("tab_2_title");
 							$subtitle2 = get_field("tab_2_subtitle");
-							$content2 = get_field("tab_2_content");	
+							$content2 = get_field("tab_2_content");
 
 							$studyImage = get_field("study_space_image");
-							
+
 							$study24 = get_field("study_24");
 							$reserveText = get_field("reserve_text");
 							if ($reserveText == "") {
@@ -81,16 +81,16 @@ get_header(); ?>
 							$reserveUrl = get_field("reserve_url");
 
 
-							
+
 							$displayPage = get_field("display_page");
 							$pageID = $displayPage->ID;
 							$pageLink = get_permalink($pageID);
-							
+
 							$description = get_the_content();
-							
+
 							$temp = $post;
 							$post = $temp;
-							
+
 
 						?>
 							<li class="flex-container study-space">

--- a/page-study-spaces.php
+++ b/page-study-spaces.php
@@ -75,7 +75,7 @@ get_header(); ?>
 
 							$study24 = get_field("study_24");
 							$reserveText = get_field("reserve_text");
-							if ($reserveText == "") {
+							if ( $reserveText == "" ) {
 								$reserveText = "Reserve Group Study Space";
 							}
 							$reserveUrl = get_field("reserve_url");
@@ -100,10 +100,10 @@ get_header(); ?>
 									<div class="description">
 										<?php echo $description; ?>
 									</div>
-									<?php if ($reserveUrl != ""): ?>
+									<?php if ( $reserveUrl != "" ) : ?>
 											<a class="reserve hidden-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
 									<?php endif; ?>
-									<?php if ($study24 == 1): ?>
+									<?php if ( $study24 == 1 ) : ?>
 										<span> | </span><a class="space247 hidden-phone" href="<?php echo $gStudy24Url; ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 									<?php endif; ?>
 									
@@ -112,30 +112,30 @@ get_header(); ?>
 										
 											<h4><?php echo $subject ?></h4>
 											<div class="sub">
-												<?php if ($phone != ""): ?>
+												<?php if ( $phone != "" ) : ?>
 												<?php echo $phone ?><br/>
 												<?php endif; ?>
 												Show on map: <a href="/locations/#!<?php echo $slug; ?>"><?php echo $building ?></a><br/>
-												<?php if (get_the_title() !== 'Information Intersection at Stata Center'): ?>
+												<?php if ( get_the_title() !== 'Information Intersection at Stata Center' ) : ?>
 													<span class="hours">Open today<br/>
 													<span data-location-hours="<?php the_title(); ?>"></span></span>
 												<?php
 													endif;
-													if ($reserveUrl != ""):
+													if ( $reserveUrl != "" ) :
 												?>
 												<a class="mobileReserve visible-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
 												<?php endif; ?>
 											</div>
 										</div>
 
-										<?php if ($individual != ""): ?>
+										<?php if ( $individual != "" ) : ?>
 										<div class="col-2">
 											<h4>Total seats</h4>
 											<?php echo $individual; ?>
 										</div>
 										<?php endif; ?>
 										
-										<?php if ($spaces != ""): ?>
+										<?php if ( $spaces != "" ) : ?>
 										<div class="col-3">
 											<h4>Group spaces</h4>
 											<?php echo $spaces; ?>

--- a/page.php
+++ b/page.php
@@ -17,15 +17,15 @@ $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;
 
-				
 
 
 
- 
+
+
 if ( is_home() ) :
 get_header('home');
-else : 
-get_header(); 
+else :
+get_header();
 endif;
 ?>
 			<?php if (in_category('shortcrumb')) { ?>

--- a/page.php
+++ b/page.php
@@ -46,7 +46,7 @@ endif;
 			
 			<?php if ( in_category('shortcrumb') ) { ?>
 			<?php get_template_part('inc/self', 'title'); ?>
-			<?php } elseif ( !in_category('page-root') ) { ?>
+			<?php } elseif ( ! in_category('page-root') ) { ?>
 			<?php get_template_part( 'inc/content','root'); ?>
 			<?php } ?>
 			

--- a/page.php
+++ b/page.php
@@ -28,7 +28,7 @@ else :
 get_header();
 endif;
 ?>
-			<?php if (in_category('shortcrumb')) { ?>
+			<?php if ( in_category('shortcrumb') ) { ?>
 		<?php get_template_part('inc/breadcrumbs', 'noChild'); ?>
 			<?php } else { ?>
 
@@ -44,16 +44,16 @@ endif;
 		
 		<div id="stage" class="inner" role="main">
 			
-			<?php if (in_category('shortcrumb')) { ?>
+			<?php if ( in_category('shortcrumb') ) { ?>
 			<?php get_template_part('inc/self', 'title'); ?>
-			<?php } elseif (!in_category('page-root')) { ?>
+			<?php } elseif ( !in_category('page-root') ) { ?>
 			<?php get_template_part( 'inc/content','root'); ?>
 			<?php } ?>
 			
 			
 			
 			<div class="content-main">
-				<?php if (in_category('shortcrumb')) { ?>
+				<?php if ( in_category('shortcrumb') ) { ?>
 				<?php get_template_part( 'content', 'shortcrumb' ); ?>
 				<?php } else { ?>				
 				<?php get_template_part( 'content', 'page' ); ?>

--- a/single-location.php
+++ b/single-location.php
@@ -2,7 +2,7 @@
 /**
  * This is the template that displays all locations.
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.1.15
+Version: 1.2.0-beta1
 
 MIT Libraries theme built for the MIT Libraries website.
 */

--- a/taxonomy-location-types.php
+++ b/taxonomy-location-types.php
@@ -2,7 +2,7 @@
 /**
  * This is the template that displays all location types.
  */
- 
+
 $pageRoot = getRoot($post);
 $section = get_post($pageRoot);
 
@@ -26,21 +26,21 @@ get_header(); ?>
 			<div class="preContent" id="locationsHome">
 				<ul class="locationMainList">
 						<?php while ( have_posts() ) : the_post(); ?>
-						<?php 
+						<?php
 							$subject = cf("subject");
 							$phone = cf("phone");
 							$building = cf("building");
 							$spaces = cf("group_spaces");
 							$equipment = cf("equipment");
 							$expert = cf("expert");
-							
+
 							$title1 = cf("tab_1_title");
 							$subtitle1 = cf("tab_1_subtitle");
 							$content1 = cf("tab_1_content");
-							
+
 							$title2 = cf("tab_2_title");
 							$subtitle2 = cf("tab_2_subtitle");
-							$content2 = cf("tab_2_content");						
+							$content2 = cf("tab_2_content");
 						?>
 							<li>
 								<div class="hours">Open today 10am - 6pm</div>
@@ -60,21 +60,21 @@ get_header(); ?>
 					<h2>More Locations</h2>
 					<ul class="locationList">
 						<?php while ( have_posts() ) : the_post(); ?>
-						<?php 
+						<?php
 							$subject = cf("subject");
 							$phone = cf("phone");
 							$building = cf("building");
 							$spaces = cf("group_spaces");
 							$equipment = cf("equipment");
 							$expert = cf("expert");
-							
+
 							$title1 = cf("tab_1_title");
 							$subtitle1 = cf("tab_1_subtitle");
 							$content1 = cf("tab_1_content");
-							
+
 							$title2 = cf("tab_2_title");
 							$subtitle2 = cf("tab_2_subtitle");
-							$content2 = cf("tab_2_content");						
+							$content2 = cf("tab_2_content");
 						?>
 							<li>
 								<h3><a href="#"><?php echo the_title() ?><i class="icon-arrow-right"></i></a></h3>

--- a/template-pages-list.php
+++ b/template-pages-list.php
@@ -43,7 +43,7 @@ get_header(); ?>
 
 	<?php
 
-		if(!current_user_can('manage_options')) {
+		if ( !current_user_can('manage_options') ) {
 			include( get_query_template( '404' ) );
 			exit();
 		}

--- a/template-pages-list.php
+++ b/template-pages-list.php
@@ -18,7 +18,7 @@ $section = get_post($pageRoot);
 $isRoot = $section->ID == $post->ID;
 
 
- 
+
 get_header(); ?>
 
 	<?php
@@ -31,12 +31,12 @@ get_header(); ?>
 	);
 
 	$template_pages = get_pages($template_page_args);
-	
+
 	$template_query_args = array (
 		'meta_key' => '_wp_page_template',
 		'meta_value' => 'page-full.php'
 	);
-	
+
 	$template_queries = get_pages($template_query_args);
 
 	?>

--- a/template-pages-list.php
+++ b/template-pages-list.php
@@ -27,7 +27,7 @@ get_header(); ?>
 	    'meta_key' => '_wp_page_template',
 	    'meta_value' => 'page-full.php',
 	    'depth' => -1,
-      'hierarchical' => 0
+	  'hierarchical' => 0
 	);
 
 	$template_pages = get_pages($template_page_args);

--- a/template-pages-list.php
+++ b/template-pages-list.php
@@ -43,7 +43,7 @@ get_header(); ?>
 
 	<?php
 
-		if ( !current_user_can('manage_options') ) {
+		if ( ! current_user_can('manage_options') ) {
 			include( get_query_template( '404' ) );
 			exit();
 		}


### PR DESCRIPTION
This is an attempt to apply the autofix routine solely to whitespace problems, which are the subject of six of 81 possible tests in CodeSniffer:

Squiz.WhiteSpace.SuperfluousWhiteSpace
Generic.WhiteSpace.ScopeIndent
Generic.WhiteSpace.DisallowSpaceIndent
WordPress.WhiteSpace.CastStructureSpacing
WordPress.WhiteSpace.ControlStructureSpacing
WordPress.WhiteSpace.OperatorSpacing

This PR applies the patch generated by each of these tests, in turn. No executable code should have been changed in this process.

I'll tag people on Slack or a code review or process advice.