### PR TITLE
Adds PHP_CodeSniffer to Grunt configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
   // Initial config
   var config = {
     pkg: grunt.file.readJSON('package.json')
-  }
+  };
 
   // Load tasks from the tasks folder
   grunt.loadTasks('tasks');
@@ -33,6 +33,9 @@ module.exports = function(grunt) {
 
   // Default Task is basically a rebuild
   grunt.registerTask('default', ['concat', 'uglify', 'sass', 'autoprefixer', 'cssmin']);
+
+  // Code analysis is handled via PHP_CodeSniffer
+  grunt.registerTask('analyze', ['phpcs']);
 
   // Moved to the tasks folder:
   // grunt.registerTask('dev', ['connect', 'watch']);

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -9,6 +9,7 @@
 	<!-- Probably need to exclude the libs directory (externally-written code) -->
 	<exclude-pattern>/libs/*</exclude-pattern>
 	<exclude-pattern>/navwalker.php</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "MITLibrares-parent",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/mitlibraries/mitlibraries-parent.git"
+  },
   "version": "2.2.0",
   "devDependencies": {
     "glob": "~3.2.8",
@@ -11,7 +15,8 @@
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-sass": "~0.7.2",
     "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-watch": "~0.5.3"
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-phpcs": "^0.4.0"
   },
   "dependencies": {
     "load-grunt-tasks": "~0.2.0"

--- a/tasks/options/phpcs.js
+++ b/tasks/options/phpcs.js
@@ -1,0 +1,16 @@
+module.exports = {
+  phpcs: {
+    application: {
+      src: [
+        '*.php',
+        'inc/**/*.php',
+        'lib/**/*.php'
+      ]
+    },
+    options: {
+      bin: 'phpcs -psvn . --extensions=php',
+      standard: './codesniffer.ruleset.xml',
+      reportFile: 'logs/grunt-analyze.log'
+    }
+  }
+};


### PR DESCRIPTION
This will allow developers to run a (properly installed) phpcs check against their local codebase with the command:

`grunt analyze`

from a terminal window. The results will be output to the terminal.