### PR TITLE
Removes third-party libraries from scanning by CodeClimate; closes #70

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -55,5 +55,13 @@ ratings:
   - "**.module"
   - "**.inc"
 exclude_paths:
+- css/bootstrap.css
+- js/jquery.cycle.js
+- js/jquery.js
+- js/libs/**/*
+- js/modernizr.js
+- js/sticky/jquery.sticky.js
+- js/sticky/scrollStick/jquery.cookie.js
+- js/superfish/superfish.min.js
 - libs/**/*
 - navwalker.php


### PR DESCRIPTION
This change excludes a series of files provided by third parties from scanning by CodeClimate. It results in no visible change to WordPress, either from visitors or administrators.