### PR TITLE
add function to force HTTPS on WP srcset image urls

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -835,3 +835,17 @@ $mimes['svg'] = 'image/svg+xml';
 return $mimes;
 }
 add_filter( 'upload_mimes', 'cc_mime_types' ); 
+
+/*
+ * Force URLs in srcset attributes into HTTPS scheme.
+ * @link: https://wordpress.org/support/topic/responsive-images-src-url-is-https-srcset-url-is-http-no-images-loaded?replies=19#post-7767555
+ */
+function ssl_srcset( $sources ) {
+  foreach ( $sources as &$source ) {
+    $source['url'] = set_url_scheme( $source['url'], 'https' );
+  }
+
+  return $sources;
+}
+add_filter( 'wp_calculate_image_srcset', 'ssl_srcset' );
+

--- a/functions.php
+++ b/functions.php
@@ -836,16 +836,16 @@ return $mimes;
 }
 add_filter( 'upload_mimes', 'cc_mime_types' ); 
 
-/*
+/**
  * Force URLs in srcset attributes into HTTPS scheme.
- * @link: https://wordpress.org/support/topic/responsive-images-src-url-is-https-srcset-url-is-http-no-images-loaded?replies=19#post-7767555
+ * @link https://wordpress.org/support/topic/responsive-images-src-url-is-https-srcset-url-is-http-no-images-loaded?replies=19#post-7767555
  */
 function ssl_srcset( $sources ) {
-  foreach ( $sources as &$source ) {
-    $source['url'] = set_url_scheme( $source['url'], 'https' );
-  }
+	foreach ( $sources as &$source ) {
+		$source['url'] = set_url_scheme( $source['url'], 'https' );
+	}
 
-  return $sources;
+	return $sources;
 }
 add_filter( 'wp_calculate_image_srcset', 'ssl_srcset' );
 


### PR DESCRIPTION
This PR addresses the problem of image srcsets generated by wordpress using http instead of https, leading to broken images and alerts about insecure content. The longer term fix is to get the settings for the all our multisites to use https at the root, but this does not conflict with that later fix.

Code review: @matt-bernhardt 
FYI: @PBruk @darcyduke