### PR TITLE
Mini-calendar position

### DIFF
--- a/js/alerts.js
+++ b/js/alerts.js
@@ -80,7 +80,7 @@ $(function mitlib_alerts(){
 					if (localStorage.getItem('alert_closed-' + alert_ID) !== 'true') {
 						// Append the template
 				  	$(alert_template).prependTo('.wrap-page');
-					$('.gldp-default').animate({"top":"262px"});
+					$('.gldp-default').animate({"top":"292px"});
 				  	// Remove the necessary transition class with a timeout, so that the animation shows.
 						setTimeout(function() {
 							$('.posts--preview--alerts').removeClass('transition-vertical--hide');


### PR DESCRIPTION
This PR adjusts hours page mini-calendar positioning when breadcrumb and site-wide alert both are present. (It is against 88_standardize_breadcrumbs since it needs the breadcrumb present to be positioned correctly.)

Fixes issue #90 

Code review: @PBruk