### PR TITLE
88 standardize breadcrumbs

### DIFF
--- a/css/partials/_breadcrumbs.scss
+++ b/css/partials/_breadcrumbs.scss
@@ -2,7 +2,7 @@
 	background: $color-secondary;
 	@include font-size(12px);
 	line-height: 1.5;
-	padding: 5px $margin-left;
+	padding: 5px 27.5px;
 	span {
 		display: block;
 		float: left;

--- a/inc/breadcrumbs-noChild.php
+++ b/inc/breadcrumbs-noChild.php
@@ -8,5 +8,5 @@
 
 ?>
 <div id="betterBreadcrumbs" class="betterBreadcrumbs" role="navigation" aria-label="breadcrumbs">
-	<span><a href="/">Home</a></span><span><?php the_title(); ?></span>
+	<span><a href="/">Libraries home</a></span><span><?php the_title(); ?></span>
 </div>

--- a/inc/breadcrumbs.php
+++ b/inc/breadcrumbs.php
@@ -8,6 +8,6 @@
 
 ?>
 <div class="breadcrumbs--better hidden-phone group" role="navigation" aria-label="breadcrumbs">
-	<span><a href="/">Home</a></span>
+	<span><a href="/">Libraries home</a></span>
 	<?php better_breadcrumbs(); ?>
 </div>

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -80,7 +80,7 @@ $(function mitlib_alerts(){
 					if (localStorage.getItem('alert_closed-' + alert_ID) !== 'true') {
 						// Append the template
 				  	$(alert_template).prependTo('.wrap-page');
-					$('.gldp-default').animate({"top":"262px"});
+					$('.gldp-default').animate({"top":"292px"});
 				  	// Remove the necessary transition class with a timeout, so that the animation shows.
 						setTimeout(function() {
 							$('.posts--preview--alerts').removeClass('transition-vertical--hide');

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -89,7 +89,9 @@ $thisWeek = date("Y-n-j");
 $alertTitle = cf("alert_title");
 $alertContent = cf("alert_content");
 
- ?>
+?>
+ 
+<?php get_template_part('inc/breadcrumbs'); ?>
 
 <div id="stage" class="hoursHeader inner hours group" role="main">
   <div class="title-page flex-container">

--- a/page-location.php
+++ b/page-location.php
@@ -17,10 +17,7 @@ $isRoot = $section->ID == $post->ID;
 
 get_header(); ?>
 		<!-- Version 1.9 -->
-		<div id="breadcrumb" class="inner" role="navigation" aria-label="breadcrumbs">
-			<a href="/">Libraries home</a>
-			&raquo; <?php showBreadTitle(); ?>
-		</div>
+		<?php get_template_part('inc/breadcrumbs'); ?>
 
 		<?php 
 			$objs = get_field("page_location");

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -23,10 +23,7 @@ get_header(); ?>
 		var showMap = <?php echo $showMap; ?>;
 	</script>	
 
-		<div id="breadcrumb" class="inner" role="navigation" aria-label="breadcrumbs">
-			<a href="/">Libraries home</a>
-			&raquo; <?php showBreadTitle(); ?>
-		</div>
+		<?php get_template_part('inc/breadcrumbs'); ?>
 
 		<div id="stage" role="main">
 			<div class="title-page flex-container">

--- a/page-search.php
+++ b/page-search.php
@@ -23,9 +23,7 @@ get_header(); ?>
 
 <?php get_template_part('inc/search'); ?>
 
-			<div id="breadcrumb" class="inner hidden-phone" role="navigation" aria-label="breadcrumbs">
-				<?php wsf_breadcrumbs(" &raquo; ", ""); ?>
-			</div>
+			<?php get_template_part('inc/breadcrumbs'); ?>
 
 			<?php while ( have_posts() ) : the_post(); ?>
 

--- a/page-study-spaces.php
+++ b/page-study-spaces.php
@@ -17,10 +17,7 @@ $section = get_post($pageRoot);
 
 get_header(); ?>
 
-		<div id="breadcrumb" class="inner" role="navigation" aria-label="breadcrumbs">
-			<a href="/">Libraries home</a>
-			&raquo; <?php showBreadTitle(); ?>
-		</div>
+		<?php get_template_part('inc/breadcrumbs'); ?>
 
 		<div id="stage" role="main">
 			<div class="title-page flex-container">

--- a/page.php
+++ b/page.php
@@ -29,12 +29,8 @@ endif;
 			<?php if (in_category('shortcrumb')) { ?>
 		<?php get_template_part('inc/breadcrumbs', 'noChild'); ?>
 			<?php } else { ?>
-
-		<div id="breadcrumb" class="inner hidden-phone" role="navigation" aria-label="breadcrumbs">
-			<?php wsf_breadcrumbs(" &raquo; ", ""); ?>
-		</div>
-		<?php } ?>
-
+		<?php get_template_part('inc/breadcrumbs'); ?>
+			<?php } ?>
 			
 			<?php while ( have_posts() ) : the_post(); ?>
 			

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.4.0-alpha1
+Version: 1.4.0-88_standardize_breadcrumbs
 
 MIT Libraries theme built for the MIT Libraries website.
 */


### PR DESCRIPTION
This branch standardizes how page templates call and display breadcrumbs across the Parent theme, as well as adjusting their styling (padding). 

Replaces #91 and puts changes against 1.4.0.