### PR TITLE
remove mention of BLC and add Borrow Direct in nav

### DIFF
--- a/inc/nav-alt.php
+++ b/inc/nav-alt.php
@@ -93,7 +93,7 @@
 						<li><a href="/getit">Get it <span class="about">Understand your options</span></a></li>
 						<li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
 						<li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
-						<li><a href="/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Boston Library Consortium, etc.</span></a></li>							
+						<li><a href="/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>							
 				        </ul>
 	              </li>
 	           </ul>

--- a/inc/nav-main.php
+++ b/inc/nav-main.php
@@ -83,7 +83,7 @@
         <a href="/getit">Get it <span class="about">Understand your options</span></a>
         <a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a>
         <a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a>
-        <a href="/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Boston Library Consortium, etc.</span></a>
+        <a href="/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR removes the mention of Boston Library Consortium now that that partnership is ending and replaces it with Borrow Direct.

Reviewers: 
- [x] @matt-bernhardt 