### PR TITLE
Appends most recent commit ID to theme version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 
 css/build/**
 js/build/**
+style.css

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,8 +31,15 @@ module.exports = function(grunt) {
 
   require('load-grunt-tasks')(grunt);
 
-  // Default Task is basically a rebuild
-  grunt.registerTask('default', ['concat', 'uglify', 'sass', 'autoprefixer', 'cssmin']);
+  // There are basically three phases of building the production theme:
+  // 1) Javascript preparation (concatenating and uglifying scripts)
+  grunt.registerTask('javascript', ['concat', 'uglify']);
+  // 2) Stylesheet preparation (SASS, autoprefixing, and minification)
+  grunt.registerTask('styles', ['sass', 'autoprefixer', 'cssmin']);
+  // 3) Appending the most recent git commit to the theme version
+  grunt.registerTask('release', ['revision', 'replace']);
+  // The default task performs all three phases.
+  grunt.registerTask('default', ['javascript', 'styles', 'release']);
 
   // Code analysis is handled via PHP_CodeSniffer
   grunt.registerTask('analyze', ['phpcs']);

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.4.0-80_responsive_study_spaces_page
+Version: 1.4.0-@@release
 
 MIT Libraries theme built for the MIT Libraries website.
 */

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "grunt-contrib-sass": "~0.7.2",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-phpcs": "^0.4.0"
+    "grunt-git-revision": "0.0.1",
+    "grunt-phpcs": "^0.4.0",
+    "grunt-replace": "^1.0.1"
   },
   "dependencies": {
     "load-grunt-tasks": "~0.2.0"

--- a/tasks/options/replace.js
+++ b/tasks/options/replace.js
@@ -1,0 +1,18 @@
+module.exports = {
+  dist: {
+    options: {
+      patterns: [
+        {
+          match: 'release',
+          replacement: '<%= meta.revision %>'
+        }
+      ]
+    },
+    files: [{
+      expand: true,
+      flatten: true,
+      src: ['css/style.css'],
+      dest: '',
+    }]
+  }
+}

--- a/tasks/options/revision.js
+++ b/tasks/options/revision.js
@@ -1,0 +1,14 @@
+module.exports = {
+  options: {
+    property: 'meta.revision',
+    ref: 'HEAD',
+    short: true
+  },
+  preprocess: {
+    options: {
+      context: {
+        revision: '<%= meta.revision %>'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Tagging for code review:
- [ ] @frrrances 
- [ ] @PBruk 

This does a few different things to the Grunt tooling we use for deploys:

1. It splits the Grunt tasks into three basic phases ("javascript", "styles", and "release"). Theoretically these could be called independently, but in reality this is meant to make the Gruntfile.js more approachable to future developers.
2. It adds the "release" phase, which looks up the most recent git commit ID and appends that to the theme's version string. The idea being that the release branch would increment the version (1.4.0, 1.5.0, etc) and the build process on each server would identify which commit (and thus which branch) was the most recently used.

I'm not necessarily proposing that this be merged into `1.4.0`, but I would like to have a conversation about whether this is useful. I suspect it will be, and should prevent future merge conflicts on the theme version string.