### PR TITLE
fix in the media link to be under /news/

### DIFF
--- a/inc/nav-main.php
+++ b/inc/nav-main.php
@@ -125,7 +125,7 @@
         <a href="/events">Classes & events</a>
         <a href="/news">News</a>
         <a href="/exhibits">Exhibits &amp; galleries</a>
-        <a href="/in-the-media">In the media</a>
+        <a href="/news/in-the-media">In the media</a>
       </div>
     </div><!-- end div.links-sub -->
   </div><!-- end div.links-primary -->


### PR DESCRIPTION
This PR fixes the "In the media" link in the About nav dropdown to go to /news/in-the-media rather than /in-the-media

code review: @matt-bernhardt 