### PR TITLE
Adjust header styles on "home" pages

### DIFF
--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -1,8 +1,12 @@
-// A lot this--colors especially--could probably be better handles with a function or two.
-.home {
+// A lot of this - colors especially - could probably be better handled with a function or two.
+
+// this rule restricts old and poorly scoped header styling to the main libraries homepage
+.libraries-home {
 	h1, h2, h3 {
 		font-weight: 300;
-	}
+	}	
+}
+.home {
 	.content-main {
 		flex-wrap: wrap;
 		@include bp-tablet--portrait {

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -10,8 +10,7 @@
 
 	get_template_part( 'inc/search' );
 ?>
-
-	<div class="content-main flex-container">
+	<div class="content-main flex-container libraries-home">
 		<div class="col-1 flex-item">
 			<div class="hours-locations">
 				<h2><a href="/hours">Hours &amp; locations</a></h2>


### PR DESCRIPTION
This PR creates a libraries homepage specific class for H1- H3 elements that won't be inherited by home pages that use the Child theme.

code review @matt-bernhardt 