### PR TITLE
Experts profile photo squished

### DIFF
--- a/css/partials/_locations.scss
+++ b/css/partials/_locations.scss
@@ -208,6 +208,8 @@
 .profile-content img {
 	position: relative;
 	border: 1px solid #999999;
+	min-width: 100px;
+	max-width: 100px;
 }
 
 .profile-content__body {


### PR DESCRIPTION
Tagging @frrrances for code-review: Add min- and max-width for profile picture to prevent shrinking. Resolves #167.


