### PR TITLE
Disables Squiz.Commenting.LongConditionClosingComment.Missing

### DIFF
--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -16,6 +16,7 @@
 		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
 		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing" />
 		<!-- Exclude the following known-failing sniffs -->
 		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedELSE" />
 		<exclude name="Generic.Files.LowercasedFilename.NotFound" />


### PR DESCRIPTION
This disables the questionable requirement for `// End if().` that CodeSniffer recently enabled. Closes #171 

Code review: @frrrances 