### PR TITLE
[WIP] [Bento] Converts search UI to a widget

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -282,7 +282,7 @@ add_filter( 'wp_page_menu_args', 'twentytwelve_page_menu_args' );
  *
  * @since Twenty Twelve 1.0
  */
-function twentytwelve_widgets_init() {
+function mitlib_widgets_init() {
 	register_sidebar( array(
 		'name' => __( 'Main Sidebar', 'twentytwelve' ),
 		'id' => 'sidebar-1',
@@ -312,8 +312,17 @@ function twentytwelve_widgets_init() {
 		'before_title' => '<h3 class="widget-title">',
 		'after_title' => '</h3>',
 	) );
+
+	register_sidebar( array(
+		'name' => __( 'Masthead Search Bar', 'twentytwelve' ),
+		'id' => 'sidebar-search',
+		'description' => __( 'Appears under the MIT Libraries masthead - principally used for the search bar', 'twentytwelve' ),
+		'before_title' => '<h3 class="widget-title">',
+		'after_title' => '</h3>',
+		'class' => '',
+	) );
 }
-add_action( 'widgets_init', 'twentytwelve_widgets_init' );
+add_action( 'widgets_init', 'mitlib_widgets_init' );
 
 if ( ! function_exists( 'twentytwelve_content_nav' ) ) :
 /**

--- a/lib/search.php
+++ b/lib/search.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This defines the search interface widget that appears throughout the theme.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.6.0
+ */
+
+/**
+ * Defines MIT Libraries' Search Widget
+ */
+class MitlibSearchWidget extends WP_Widget {
+
+	/**
+	 * Constructor
+	 */
+	function __construct() {
+		$name = 'Libraries Search';
+		parent::WP_Widget( false, $name );
+	}
+
+	/**
+	 * Widget method
+	 *
+	 * @see WP_Widget::widget -- do not rename this
+	 * @param object $args See Wordpress documentation.
+	 * @param object $instance See Wordpress documentation.
+	 */
+	function widget( $args, $instance ) {
+		?>
+<div id="search-main" class="search--lib-resources flex-container <?php echo esc_attr( $args['class'] ); ?>">
+	<?php
+		load_template( dirname( __FILE__ ) . '/templates/search.html' );
+	?>
+	<a href="<?php echo esc_url( $instance['eds_advanced'] ); ?>" class="search-advanced bartonplus active no-js-hidden">Go to BartonPlus advanced search</a>
+	<a href="https://libraries.mit.edu/barton-advanced" class="search-advanced barton no-js-hidden">Go to Barton advanced search</a>
+	<a href="https://mit.worldcat.org/advancedsearch" class="search-advanced worldcat no-js-hidden">Go to WorldCat advanced search</a>
+	<a href="https://libraries.mit.edu/barton-reserves" class="search-advanced course-reserves no-js-hidden">Go to Course Reserves advanced search</a>
+</div><!-- end div.search-main -->
+		<?php
+	}
+
+	/**
+	 * Update method
+	 *
+	 * @see WP_Widget::update -- do not rename this
+	 * @param object $new_instance See Wordpress widget documentation.
+	 * @param object $old_instance See Wordpress widget documentation.
+	 */
+	function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
+		$instance['eds_advanced'] = esc_url_raw( $new_instance['eds_advanced'] );
+		return $instance;
+	}
+
+	/**
+	 * Form method
+	 *
+	 * @see WP_Widget::form -- do not rename this
+	 * @param object $instance See Wordpress widget documentation.
+	 */
+	function form( $instance ) {
+		$eds_advanced = esc_attr( $instance['eds_advanced'] );
+
+		?>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'eds_advanced' ) ); ?>"><?php esc_attr_e( 'EDS Advanced Search URL:' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'eds_advanced' ) ); ?>" type="text" name="<?php echo esc_attr( $this->get_field_name( 'eds_advanced' ) ); ?>" value="<?php echo esc_url( $eds_advanced ); ?>">
+		</p>
+		<?php
+	}
+} // End class MitlibSearchWidget.
+
+$mitlib_search = function() {
+	return register_widget( 'MitlibSearchWidget' );
+};
+
+add_action( 'widgets_init', $mitlib_search );

--- a/lib/templates/search.html
+++ b/lib/templates/search.html
@@ -1,13 +1,3 @@
-<?php
-/**
- * Template for search bar
- *
- * @package MIT_Libraries_Parent
- * @since 1.2.1
- */
-
-?>
-<div id="search-main" class="search--lib-resources flex-container">
 	<h2>Search</h2>
 	<div class="search-options--static flex-container js-hidden">
 		<div class="col-1">
@@ -139,8 +129,3 @@
 			<option value="keyword" selected="selected">Keyword</option>
 		</select>
 	</div>
-	<a href="https://libraries.mit.edu/bartonplus-advanced" class="search-advanced bartonplus active no-js-hidden">Go to BartonPlus advanced search</a>
-	<a href="https://libraries.mit.edu/barton-advanced" class="search-advanced barton no-js-hidden">Go to Barton advanced search</a>
-	<a href="https://mit.worldcat.org/advancedsearch" class="search-advanced worldcat no-js-hidden">Go to WorldCat advanced search</a>
-	<a href="https://libraries.mit.edu/barton-reserves" class="search-advanced course-reserves no-js-hidden">Go to Course Reserves advanced search</a>
-</div><!-- end div.search-main -->

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -8,8 +8,11 @@
 
 	get_header( 'home' );
 
-	get_template_part( 'inc/search' );
-?>
+if ( is_active_sidebar( 'sidebar-search' ) ) : ?>
+	<div id="sidebar-search" class="widget-area" role="complementary">
+		<?php dynamic_sidebar( 'sidebar-search' ); ?>
+	</div>
+<?php endif; ?>
 	<div class="content-main flex-container libraries-home">
 		<div class="col-1 flex-item">
 			<div class="hours-locations">

--- a/page-search.php
+++ b/page-search.php
@@ -11,10 +11,14 @@
  * @since 1.2.1
  */
 
-get_header(); ?>
+get_header();
 
-		<?php get_template_part( 'inc/search' ); ?>
-		
+if ( is_active_sidebar( 'sidebar-search' ) ) : ?>
+	<div id="sidebar-search" class="widget-area" role="complementary">
+		<?php dynamic_sidebar( 'sidebar-search' ); ?>
+	</div>
+<?php endif; ?>
+
 		<?php get_template_part( 'inc/breadcrumbs' ); ?>
 
 		<?php while ( have_posts() ) : the_post(); ?>

--- a/page.php
+++ b/page.php
@@ -25,6 +25,13 @@ get_header( 'home' );
 else :
 get_header();
 endif;
+
+if ( is_active_sidebar( 'sidebar-search' ) ) : ?>
+	<div id="sidebar-search" class="widget-area" role="complementary">
+		<?php dynamic_sidebar( 'sidebar-search' ); ?>
+	</div>
+<?php
+endif;
 ?>
 			<?php if ( in_category( 'shortcrumb' ) ) { ?>
 		<?php get_template_part( 'inc/breadcrumbs', 'noChild' ); ?>


### PR DESCRIPTION
This could allow us to do several things:
- Eliminate the search template `page-search.php`
- Enable configuration of the search UI via the WP admin screens
- More easily share the code with other organizations (baby steps towards a plugin)

This is being considered as part of the Bento project. I know I'd like to get @frrrances thoughts, but possibly also @JPrevost or @szendeh once things get a bit farther along?

This is probably mutually exclusive with #175 
