### PR TITLE
Remove deprecated functions

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -25,10 +25,13 @@ get_header(); ?>
 			<header class="archive-header">
 				<h1 class="archive-title"><?php
 					if ( is_day() ) :
+						// Translators: Today's date.
 						printf( __( 'Daily Archives: %s', 'twentytwelve' ), '<span>' . get_the_date() . '</span>' );
 					elseif ( is_month() ) :
+						// Translators: Today's month.
 						printf( __( 'Monthly Archives: %s', 'twentytwelve' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', 'twentytwelve' ) ) . '</span>' );
 					elseif ( is_year() ) :
+						// Translators: Today's year.
 						printf( __( 'Yearly Archives: %s', 'twentytwelve' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', 'twentytwelve' ) ) . '</span>' );
 					else :
 						_e( 'Archives', 'twentytwelve' );

--- a/author.php
+++ b/author.php
@@ -30,7 +30,11 @@ get_header(); ?>
 			?>
 
 			<header class="archive-header">
-				<h1 class="archive-title"><?php printf( __( 'Author Archives: %s', 'twentytwelve' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' ); ?></h1>
+				<h1 class="archive-title">
+					<?php
+					// Translators: Author's name.
+					printf( __( 'Author Archives: %s', 'twentytwelve' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' ); ?>
+				</h1>
 			</header><!-- .archive-header -->
 
 			<?php
@@ -53,7 +57,10 @@ get_header(); ?>
 					<?php echo get_avatar( get_the_author_meta( 'user_email' ), apply_filters( 'twentytwelve_author_bio_avatar_size', 60 ) ); ?>
 				</div><!-- .author-avatar -->
 				<div class="author-description">
-					<h2><?php printf( __( 'About %s', 'twentytwelve' ), get_the_author() ); ?></h2>
+					<h2><?php
+						// Translators: Author's name.
+						printf( __( 'About %s', 'twentytwelve' ), get_the_author() ); ?>
+					</h2>
 					<p><?php the_author_meta( 'description' ); ?></p>
 				</div><!-- .author-description	-->
 			</div><!-- .author-info -->

--- a/category.php
+++ b/category.php
@@ -18,7 +18,11 @@ get_header(); ?>
 		<div class="content-main main-content">
 		<?php if ( have_posts() ) : ?>
 			<header class="archive-header">
-				<h1 class="archive-title"><?php printf( __( 'Category Archives: %s', 'twentytwelve' ), '<span>' . single_cat_title( '', false ) . '</span>' ); ?></h1>
+				<h1 class="archive-title">
+					<?php
+					// Translators: Category name.
+					printf( __( 'Category Archives: %s', 'twentytwelve' ), '<span>' . single_cat_title( '', false ) . '</span>' ); ?>
+				</h1>
 
 			<?php if ( category_description() ) : // Show an optional category description. ?>
 				<div class="archive-meta"><?php echo category_description(); ?></div>

--- a/comments.php
+++ b/comments.php
@@ -27,6 +27,7 @@ if ( post_password_required() ) {
 	<?php if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
+				// Translators: Post title.
 				printf( _n( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'twentytwelve' ),
 					number_format_i18n( get_comments_number() ), '<span>' . get_the_title() . '</span>' );
 			?>

--- a/content-aside.php
+++ b/content-aside.php
@@ -10,14 +10,19 @@
 
 	<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 		<div class="aside">
-			<h1 class="entry-title"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
+			<h1 class="entry-title"><a href="<?php the_permalink(); ?>" title="<?php
+				// Translators: Permalink text.
+				echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a>
+			</h1>
 			<div class="entry-content">
 				<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentytwelve' ) ); ?>
 			</div><!-- .entry-content -->
 		</div><!-- .aside -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
+			<a href="<?php the_permalink(); ?>" title="<?php
+				// Translators: Permalink text.
+				echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">
 				<?php comments_popup_link( '<span class="leave-reply">' . __( 'Leave a reply', 'twentytwelve' ) . '</span>', __( '1 Reply', 'twentytwelve' ), __( '% Replies', 'twentytwelve' ) ); ?>

--- a/content-hours.php
+++ b/content-hours.php
@@ -166,40 +166,6 @@
 					</div>
 				</div>
 				<?php get_sidebar(); ?>
-				<!--
-				<div id="sidebarContent">
-					<div class="sidebarWidgets">
-						<div class="widget">
-							<h3>Help with renewing, fines, requests...</h3>
-							<ul>
-								<li><a href="#">Circulation FAQ</a></li>
-								<li><a href="#">Reserves FAQ</a></li>
-								<li><a href="#">Other FAQs</a></li>
-								<li><a href="#">Get books, articles, and more...</a></li>
-							</ul>
-						</div>
-						<?php $val = $spaces; if ( $val != '' ) : ?>
-						<div class="widget">
-							<?php echo $val; ?>
-						</div>
-						<?php endif; ?>
-						<?php $val = $equipment; if ( $val != '' ) : ?>
-						<div class="widget">
-							<?php echo $val; ?>
-						</div>
-						<?php endif; ?>
-						<div class="widget">
-							<h3>See also</h3>
-							<ul>
-								<li><a href="#">School of Architecture &amp; Planning</a></li>
-							</ul>
-						</div>
-					</div>
-				</div>					
-				-->
-			
-			
-			
 		
 			<div class="clear"></div>
 		

--- a/content-hours.php
+++ b/content-hours.php
@@ -76,7 +76,9 @@
 				<div id="mainContent">
 					
 					<?php if ( $title1 != '' || $title2 != '' ) : ?>
-						<?php $noTab = '';  ?>
+						<?php
+						$noTab = '';
+						?>
 					<ul class="tabnav">
 						<?php if ( $title1 != '' ) : ?>
 						<li class="active"><a href="#tab1"><?php echo $title1 ?><div><?php echo $subtitle1 ?></div></a></li>
@@ -85,9 +87,9 @@
 						<li><a href="#tab2"><?php echo $title2 ?><div><?php echo $subtitle2 ?></div></a></li>
 						<?php endif; ?>
 					</ul>
-					<?php else : ?>
-						<?php $noTab = ' noTab';  ?>
-					<?php endif; ?>
+					<?php else :
+						$noTab = ' noTab';
+					endif; ?>
 					<div class="tabcontent <?php echo $noTab ?>">
 						<div class="tab active" id="tab1">
 							<div class="row">

--- a/content-image.php
+++ b/content-image.php
@@ -14,7 +14,9 @@
 		</div><!-- .entry-content -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark">
+			<a href="<?php the_permalink(); ?>" title="<?php
+				// Translators: Permalink text.
+				echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark">
 				<h1><?php the_title(); ?></h1>
 				<h2><time class="entry-date" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>"><?php echo get_the_date(); ?></time></h2>
 			</a>

--- a/content-link.php
+++ b/content-link.php
@@ -15,7 +15,9 @@
 		</div><!-- .entry-content -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
+			<a href="<?php the_permalink(); ?>" title="<?php
+				// Translators: Permalink text.
+				echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">
 				<?php comments_popup_link( '<span class="leave-reply">' . __( 'Leave a reply', 'twentytwelve' ) . '</span>', __( '1 Reply', 'twentytwelve' ), __( '% Replies', 'twentytwelve' ) ); ?>

--- a/content-location.php
+++ b/content-location.php
@@ -32,10 +32,14 @@
 	$content2 = get_field( 'tab_2_content' );
 
 	$content2wide = 0;
-	if ( $content2 == '' ) { $content2wide = 1; }
+	if ( $content2 == '' ) {
+		$content2wide = 1;
+	}
 
 	$content1wide = 0;
-	if ( $content1 == '' ) { $content1wide = 1; }
+	if ( $content1 == '' ) {
+		$content1wide = 1;
+	}
 
 	$study24 = get_field( 'study_24' );
 
@@ -52,7 +56,9 @@
 
 
 	$expertAskUrl = get_field( 'expert_ask_url' );
-	if ( $expertAskUrl == '' ) { $expertAskUrl = 'http://libraries.mit.edu/ask'; }
+	if ( $expertAskUrl == '' ) {
+		$expertAskUrl = 'http://libraries.mit.edu/ask';
+	}
 
 
 	$numMain = 6;
@@ -138,8 +144,10 @@
 	<div id="content" class="content <?php echo $strLocation; ?> has-sidebar">
 		<div class="main-content content-main">
 
-			<?php if ( $title1 != '' || $title2 != '' ) : ?>
-				<?php $noTab = '';  ?>
+			<?php
+			if ( $title1 != '' || $title2 != '' ) :
+				$noTab = '';
+			?>
 			<ul class="tabnav">
 				<?php if ( $title1 != '' ) : ?>
 				<li class="active tab1st"><h2 class="title-tab"><a href="#tab1"><?php echo $title1 ?><span class="title-sub hidden-mobile"><?php echo $subtitle1 ?></span class="title-sub"></a></h2></li>
@@ -148,9 +156,11 @@
 				<li class="tab2nd"><h2 class="title-tab"><a href="#tab2"><?php echo $title2 ?><span class="title-sub hidden-mobile"><?php echo $subtitle2 ?></span class="title-sub"></a></h2></li>
 				<?php endif; ?>
 			</ul>
-			<?php else : ?>
-				<?php $noTab = ' noTab';  ?>
-			<?php endif; ?>
+			<?php
+			else :
+				$noTab = ' noTab';
+			endif;
+			?>
 
 			<div class="tabcontent group <?php echo $noTab ?>">
 

--- a/content-location.php
+++ b/content-location.php
@@ -32,12 +32,12 @@
 	$content2 = get_field( 'tab_2_content' );
 
 	$content2wide = 0;
-	if ( $content2 == '' ) {
+	if ( '' === $content2 ) {
 		$content2wide = 1;
 	}
 
 	$content1wide = 0;
-	if ( $content1 == '' ) {
+	if ( '' === $content1 ) {
 		$content1wide = 1;
 	}
 
@@ -48,7 +48,7 @@
 
 
 	$reserveText = get_field( 'reserve_text' );
-	if ( $reserveText == '' ) {
+	if ( '' === $reserveText ) {
 		$reserveText = 'Reserve Group Study Space';
 	}
 	$reserveUrl = get_field( 'reserve_url' );
@@ -56,7 +56,7 @@
 
 
 	$expertAskUrl = get_field( 'expert_ask_url' );
-	if ( $expertAskUrl == '' ) {
+	if ( '' === $expertAskUrl ) {
 		$expertAskUrl = 'http://libraries.mit.edu/ask';
 	}
 
@@ -145,14 +145,14 @@
 		<div class="main-content content-main">
 
 			<?php
-			if ( $title1 != '' || $title2 != '' ) :
+			if ( '' != $title1 || '' != $title2 ) :
 				$noTab = '';
 			?>
 			<ul class="tabnav">
-				<?php if ( $title1 != '' ) : ?>
+				<?php if ( '' != $title1 ) : ?>
 				<li class="active tab1st"><h2 class="title-tab"><a href="#tab1"><?php echo $title1 ?><span class="title-sub hidden-mobile"><?php echo $subtitle1 ?></span class="title-sub"></a></h2></li>
 				<?php endif; ?>
-				<?php if ( $title2 != '' ) : ?>
+				<?php if ( '' != $title2 ) : ?>
 				<li class="tab2nd"><h2 class="title-tab"><a href="#tab2"><?php echo $title2 ?><span class="title-sub hidden-mobile"><?php echo $subtitle2 ?></span class="title-sub"></a></h2></li>
 				<?php endif; ?>
 			</ul>

--- a/content-quote.php
+++ b/content-quote.php
@@ -14,7 +14,9 @@
 		</div><!-- .entry-content -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
+			<a href="<?php the_permalink(); ?>" title="<?php
+				// Translators: Permalink text.
+				echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">
 				<?php comments_popup_link( '<span class="leave-reply">' . __( 'Leave a reply', 'twentytwelve' ) . '</span>', __( '1 Reply', 'twentytwelve' ), __( '% Replies', 'twentytwelve' ) ); ?>

--- a/content-status.php
+++ b/content-status.php
@@ -12,7 +12,9 @@
 		<div class="entry-header">
 			<header>
 				<h1><?php the_author(); ?></h1>
-				<h2><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a></h2>
+				<h2><a href="<?php the_permalink(); ?>" title="<?php
+					// Translators: Permalink text.
+					echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a></h2>
 			</header>
 			<?php echo get_avatar( get_the_author_meta( 'ID' ), apply_filters( 'twentytwelve_status_avatar', '48' ) ); ?>
 		</div><!-- .entry-header -->

--- a/content.php
+++ b/content.php
@@ -20,7 +20,10 @@
 			<h1 class="entry-title"><?php the_title(); ?></h1>
 			<?php else : ?>
 			<h1 class="entry-title">
-				<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a>
+				<a href="<?php the_permalink(); ?>" title="<?php
+					// Translators: Permalink text.
+					echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?>
+				</a>
 			</h1>
 			<?php endif; // is_single(). ?>
 			<?php if ( comments_open() ) : ?>
@@ -50,11 +53,16 @@
 						<?php echo get_avatar( get_the_author_meta( 'user_email' ), apply_filters( 'twentytwelve_author_bio_avatar_size', 68 ) ); ?>
 					</div><!-- .author-avatar -->
 					<div class="author-description">
-						<h2><?php printf( __( 'About %s', 'twentytwelve' ), get_the_author() ); ?></h2>
+						<h2><?php
+							// Translators: About the author.
+							printf( __( 'About %s', 'twentytwelve' ), get_the_author() ); ?>
+						</h2>
 						<p><?php the_author_meta( 'description' ); ?></p>
 						<div class="author-link">
 							<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-								<?php printf( __( 'View all posts by %s <span class="meta-nav">&rarr;</span>', 'twentytwelve' ), get_the_author() ); ?>
+								<?php
+								// Translators: View all posts by author.
+								printf( __( 'View all posts by %s <span class="meta-nav">&rarr;</span>', 'twentytwelve' ), get_the_author() ); ?>
 							</a>
 						</div><!-- .author-link -->
 					</div><!-- .author-description -->

--- a/functions.php
+++ b/functions.php
@@ -676,9 +676,9 @@ function remove_template( $files_to_delete = array() ) {
 	$files_to_delete = preg_replace( '/\.[^.]+$/', '', $files_to_delete );
 
 	// Populate the global $wp_themes array.
-	get_themes();
+	wp_get_themes();
 
-	$current_theme_name = get_current_theme();
+	$current_theme_name = wp_get_theme();
 
 	// Note that we're taking a reference to $wp_themes so we can modify it in-place.
 	$template_files = &$wp_themes[ $current_theme_name ]['Template Files'];

--- a/functions.php
+++ b/functions.php
@@ -259,7 +259,9 @@ function twentytwelve_wp_title( $title, $sep ) {
 
 	// Add a page number if necessary.
 	if ( $paged >= 2 || $page >= 2 ) {
-		$title = "$title $sep " . sprintf( __( 'Page %s', 'twentytwelve' ), max( $paged, $page ) ); }
+		// Translators: Page number for multi-page content.
+		$title = "$title $sep " . sprintf( __( 'Page %s', 'twentytwelve' ), max( $paged, $page ) );
+	}
 
 	return $title;
 }
@@ -424,16 +426,20 @@ function twentytwelve_entry_meta() {
 
 	$author = sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>',
 		esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+		// Translators: View all posts by a given author.
 		esc_attr( sprintf( __( 'View all posts by %s', 'twentytwelve' ), get_the_author() ) ),
 		get_the_author()
 	);
 
 	// Translators: 1 is category, 2 is tag, 3 is the date and 4 is the author's name.
 	if ( $tag_list ) {
+		// Translators: Category, tag, date, and author values.
 		$utility_text = __( 'This entry was posted in %1$s and tagged %2$s on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
 	} elseif ( $categories_list ) {
+		// Translators: Category, date, and author values.
 		$utility_text = __( 'This entry was posted in %1$s on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
 	} else {
+		// Translators: Date and author values.
 		$utility_text = __( 'This entry was posted on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
 	}
 
@@ -604,7 +610,9 @@ function the_breadcrumb() {
 }
 
 function wsf_make_link( $url, $anchortext, $title = null, $nofollow = false ) {
-	if ( $title == null ) { $title = $anchortext; }
+	if ( $title == null ) {
+		$title = $anchortext;
+	}
 	$nofollow == true ? $rel = ' rel="nofollow"' : $rel = '';
 
 	$link = sprintf( '<a href="%s" title="%s" %s="">%s</a>', $url, $title, $rel, $anchortext );
@@ -670,7 +678,9 @@ function remove_template( $files_to_delete = array() ) {
 	global $wp_themes;
 
 	// As convenience, allow a single value to be used as a scalar without wrapping it in a useless array().
-	if ( is_scalar( $files_to_delete ) ) { $files_to_delete = array( $files_to_delete ); }
+	if ( is_scalar( $files_to_delete ) ) {
+		$files_to_delete = array( $files_to_delete );
+	}
 
 	// Remove TLA if it was provided.
 	$files_to_delete = preg_replace( '/\.[^.]+$/', '', $files_to_delete );

--- a/functions.php
+++ b/functions.php
@@ -610,7 +610,7 @@ function the_breadcrumb() {
 }
 
 function wsf_make_link( $url, $anchortext, $title = null, $nofollow = false ) {
-	if ( $title == null ) {
+	if ( null === $title ) {
 		$title = $anchortext;
 	}
 	$nofollow == true ? $rel = ' rel="nofollow"' : $rel = '';

--- a/header-home.php
+++ b/header-home.php
@@ -28,7 +28,7 @@
 <?php
 		// $askUrl = get_post_meta($post->ID, "ask_us_override", 1);
 		$askUrl = '';
-		if ( $askUrl == '' ) {
+		if ( '' === $askUrl ) {
 			$askUrl = '/ask';
 		}
 ?>

--- a/header-home.php
+++ b/header-home.php
@@ -28,7 +28,9 @@
 <?php
 		// $askUrl = get_post_meta($post->ID, "ask_us_override", 1);
 		$askUrl = '';
-		if ( $askUrl == '' ) { $askUrl = '/ask'; }
+		if ( $askUrl == '' ) {
+			$askUrl = '/ask';
+		}
 ?>
 	<script>
 		todayDate="";

--- a/header.php
+++ b/header.php
@@ -25,7 +25,9 @@
 <?php
 		// $askUrl = get_post_meta($post->ID, "ask_us_override", 1);
 		$askUrl = '';
-		if ( $askUrl == '' ) { $askUrl = '/ask'; }
+		if ( $askUrl == '' ) {
+			$askUrl = '/ask';
+		}
 ?>
 	<script>
 		todayDate="";

--- a/header.php
+++ b/header.php
@@ -25,7 +25,7 @@
 <?php
 		// $askUrl = get_post_meta($post->ID, "ask_us_override", 1);
 		$askUrl = '';
-		if ( $askUrl == '' ) {
+		if ( '' === $askUrl ) {
 			$askUrl = '/ask';
 		}
 ?>

--- a/image.php
+++ b/image.php
@@ -28,6 +28,7 @@ get_header(); ?>
 						<footer class="entry-meta">
 							<?php
 								$metadata = wp_get_attachment_metadata();
+								// Translators: Image attribution line with many values.
 								printf( __( '<span class="meta-prep meta-prep-entry-date">Published </span> <span class="entry-date"><time class="entry-date" datetime="%1$s">%2$s</time></span> at <a href="%3$s" title="Link to full-size image">%4$s &times; %5$s</a> in <a href="%6$s" title="Return to %7$s" rel="gallery">%8$s</a>.', 'twentytwelve' ),
 									esc_attr( get_the_date( 'c' ) ),
 									esc_html( get_the_date() ),

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -139,7 +139,8 @@ function twentytwelve_admin_header_image() {
 		?>
 		<h1><a id="name"<?php echo $style; ?> onclick="return false;" href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
 		<h2 id="desc"<?php echo $style; ?>><?php bloginfo( 'description' ); ?></h2>
-		<?php $header_image = get_header_image();
+		<?php
+		$header_image = get_header_image();
 		if ( ! empty( $header_image ) ) : ?>
 			<img src="<?php echo esc_url( $header_image ); ?>" class="header-image" width="<?php echo get_custom_header()->width; ?>" height="<?php echo get_custom_header()->height; ?>" alt="" />
 		<?php endif; ?>

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -14,7 +14,7 @@ if ( isset( $_GET['cleanCache'] ) ) {
 
 $resetCache = 0;
 
-if ( $clean == '1' ) {
+if ( '1' === $clean ) {
 	$resetCache = 1;
 }
 $halfCache = 0;
@@ -500,7 +500,7 @@ function getTermHour( $term, $dt ) {
 
 			$end = $hours['end'];
 
-			if ( $end == '' ) {
+			if ( '' === $end ) {
 				$end = $start;
 			}
 

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -1029,7 +1029,7 @@ function locationNameToIdOriginal( $name ) {
 function title_filter( $where, &$wp_query ) {
 	global $wpdb;
 	if ( $search_term = $wp_query->get( 'search_prod_title' ) ) {
-		$where .= ' AND ' . $wpdb->posts . '.post_title LIKE \'%' . esc_sql( like_escape( $search_term ) ) . '%\'';
+		$where .= ' AND ' . $wpdb->posts . '.post_title LIKE \'%' . esc_sql( $wpdb->esc_like( $search_term ) ) . '%\'';
 	}
 	return $where;
 }

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -14,7 +14,9 @@ if ( isset( $_GET['cleanCache'] ) ) {
 
 $resetCache = 0;
 
-if ( $clean == '1' ) { $resetCache = 1; }
+if ( $clean == '1' ) {
+	$resetCache = 1;
+}
 $halfCache = 0;
 
 if ( isset( $_GET['locReset'] ) ) {
@@ -498,7 +500,9 @@ function getTermHour( $term, $dt ) {
 
 			$end = $hours['end'];
 
-			if ( $end == '' ) { $end = $start; }
+			if ( $end == '' ) {
+				$end = $start;
+			}
 
 			$dt = strtotime( date( 'Ymd', $dt ) );
 
@@ -1028,7 +1032,7 @@ function locationNameToIdOriginal( $name ) {
 
 function title_filter( $where, &$wp_query ) {
 	global $wpdb;
-	if ( $search_term = $wp_query->get( 'search_prod_title' ) ) {
+	if ( $search_term == $wp_query->get( 'search_prod_title' ) ) {
 		$where .= ' AND ' . $wpdb->posts . '.post_title LIKE \'%' . esc_sql( $wpdb->esc_like( $search_term ) ) . '%\'';
 	}
 	return $where;

--- a/page-featured-news.php
+++ b/page-featured-news.php
@@ -120,20 +120,6 @@
 					echo    	$imageTag;
 					echo    '</div>';
 
-					echo '<div class="control" style="background-color:#fdd;">';
-					echo '<span>Post metadata</span><br>';
-					echo '<pre class="toggle meta">';
-					print_r( $post );
-					echo '</pre>';
-					echo '</div>';
-
-					echo '<div class="control" style="background-color:#dfd;">';
-					echo '<span>Custom values</span><br>';
-					echo '<pre class="toggle meta">';
-					print_r( $custom );
-					echo '</pre>';
-					echo '</div>';
-
 					echo '</div>';
 
 				endwhile;
@@ -150,14 +136,6 @@
 <?php
 	get_footer();
 ?>
-<script>
-jQuery(function() {
-	// This drives the show/hide toggles on post metadata.
-	jQuery(".control span").click(function() {
-		jQuery(this).parent().find(".toggle").toggleClass("meta");
-	})
-});
-</script>
 <style type="text/css">
 .debug .post--full-bleed.no-underline {
 	border:1px solid black; 
@@ -169,15 +147,5 @@ jQuery(function() {
 	margin-bottom: 1rem;
 	background-color: #ddf;
 	border: 1px solid blue;
-}
-.debug .control {
-	margin-bottom: 1rem;
-	font-family: monospace;
-	font-size: 12px;
-}
-.debug .control span {
-	font-size: 1.2rem;
-	padding: 0.5rem;
-
 }
 </style>

--- a/page-featured-news.php
+++ b/page-featured-news.php
@@ -123,14 +123,14 @@
 					echo '<div class="control" style="background-color:#fdd;">';
 					echo '<span>Post metadata</span><br>';
 					echo '<pre class="toggle meta">';
-					var_dump( $post );
+					print_r( $post );
 					echo '</pre>';
 					echo '</div>';
 
 					echo '<div class="control" style="background-color:#dfd;">';
 					echo '<span>Custom values</span><br>';
 					echo '<pre class="toggle meta">';
-					var_dump( $custom );
+					print_r( $custom );
 					echo '</pre>';
 					echo '</div>';
 

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -160,9 +160,12 @@ tr:nth-child(even) td {
 	  <thead>
 		<tr>
 	  <th class="name">Locations</th>
-		<?php $next = ''; ?>
-		<?php $i = 0;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$next = '';
+
+		$i = 0;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay firstDisplay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -171,8 +174,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 1;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 1;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -181,8 +186,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 2;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 2;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -191,8 +198,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 3;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 3;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -201,8 +210,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 4;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 4;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -211,8 +222,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 5;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 5;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -221,8 +234,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 6;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 6;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -253,12 +268,13 @@ $mapPage = '/locations/#!';
 ?>
 		<tr data-location="<?php the_title(); ?>">
 		  <td width="260" class="name"><div class="nameHolder">
-			  <h3> <a href="<?php $post_object = get_field( 'display_page' );
-			  if ( $post_object ) :
-		  // Dont even ask why.
-			$post = $post_object;
-			setup_postdata( $post );
-			?>
+			  <h3> <a href="<?php
+					$post_object = get_field( 'display_page' );
+					if ( $post_object ) :
+						// Dont even ask why.
+						$post = $post_object;
+						setup_postdata( $post );
+				?>
 			<?php the_permalink(); ?>">
 				<?php the_title(); ?>
 				</a></h3>
@@ -302,9 +318,12 @@ endwhile;    ?>
 	  <thead>
 		<tr>
 	  <th class="name">More Locations</th>
-		<?php $next = ''; ?>
-		<?php $i = 0;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$next = '';
+
+		$i = 0;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay firstDisplay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -313,8 +332,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 1;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 1;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -323,8 +344,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 2;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 2;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -333,8 +356,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 3;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 3;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -343,8 +368,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 4;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 4;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -353,8 +380,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 5;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 5;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';
@@ -363,8 +392,10 @@ $next = 'curAfter';} ?>"> <span class="fullDay"><?php echo date( 'l', $day ); ?>
 		  </span> <span class="mobileDay"><?php echo date( 'D', $day ); ?>
 		  <div class='date'><?php echo date( $dfDowMobile, $day );?></div>
 		  </span> </th>
-		<?php $i = 6;
-$day = $arDays[ $i ]; ?>
+		<?php
+		$i = 6;
+		$day = $arDays[ $i ];
+		?>
 		<th class="fullDay <?php echo $next;
 $next = '';
 if ( $now == $day ) { echo 'cur';

--- a/search.php
+++ b/search.php
@@ -14,7 +14,10 @@ get_header(); ?>
 		<?php if ( have_posts() ) : ?>
 
 			<header class="page-header">
-				<h1 class="page-title"><?php printf( __( 'Search Results for: %s', 'twentytwelve' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
+				<h1 class="page-title"><?php
+					// Translators: Search results for a given term.
+					printf( __( 'Search Results for: %s', 'twentytwelve' ), '<span>' . get_search_query() . '</span>' ); ?>
+				</h1>
 			</header>
 
 			<?php twentytwelve_content_nav( 'nav-above' ); ?>

--- a/tag.php
+++ b/tag.php
@@ -17,7 +17,10 @@ get_header(); ?>
 
 		<?php if ( have_posts() ) : ?>
 			<header class="archive-header">
-				<h1 class="archive-title"><?php printf( __( 'Tag Archives: %s', 'twentytwelve' ), '<span>' . single_tag_title( '', false ) . '</span>' ); ?></h1>
+				<h1 class="archive-title"><?php
+					// Translators: Tag archives fora given tag.
+					printf( __( 'Tag Archives: %s', 'twentytwelve' ), '<span>' . single_tag_title( '', false ) . '</span>' ); ?>
+				</h1>
 
 			<?php if ( tag_description() ) : // Show an optional tag description. ?>
 				<div class="archive-meta"><?php echo tag_description(); ?></div>


### PR DESCRIPTION
The recent upgrade of PHP's CodeSniffer has introduced a few new checks which are failing in our theme. For example, see [this recent Travis run](https://travis-ci.org/MITLibraries/MITlibraries-parent/jobs/190636799). Specifically:

```
PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
----------------------------------------------------------------------
SOURCE                                                           COUNT
----------------------------------------------------------------------
Squiz.PHP.DisallowMultipleAssignments.Found                      34
WordPress.WP.I18n.MissingTranslatorsComment                      24
WordPress.PHP.DevelopmentFunctions.error_log                     2
WordPress.WP.DeprecatedFunctions.get_current_theme               1
WordPress.WP.DeprecatedFunctions.like_escape                     1
WordPress.WP.DeprecatedFunctions.get_themes                      1
----------------------------------------------------------------------
A TOTAL OF 63 SNIFF VIOLATIONS WERE FOUND IN 6 SOURCES
----------------------------------------------------------------------
```

To address the violations individually:

- Squiz.PHP.DisallowMultipleAssignments.Found

There's a number of these, but most of them boil down to something like https://github.com/MITLibraries/MITlibraries-parent/blob/9cdb0457ae07772851aa34edb459d178e5487830/page-hours-json.php#L184  
```
...
		  </span> </th>
		<?php $i = 2;
$day = $arDays[ $i ]; ?>
...
```
Basically you have to open the PHP block on one line, and then take the first action on the next:
```
...
		  </span> </th>
		<?php
$i = 2;
$day = $arDays[ $i ]; ?>
...
```

- WordPress.WP.I18n.MissingTranslatorsComment
This is clarified at https://codex.wordpress.org/I18n_for_WordPress_Developers#Descriptions - when using translation functions, it is preferred to add a comment immediately beforehand to give a hint to people building translations. I'm not sure how much attention our themes will get from translators, but these seem harmless enough.

- The rest of the violations are one-off changes that were solved in the first few commits - mostly be removing part of a rarely-if-ever used page.

This closes #182.