### PR TITLE
[Bento] Define search sidebar, adds display logic to templates

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -284,7 +284,7 @@ add_filter( 'wp_page_menu_args', 'twentytwelve_page_menu_args' );
  *
  * @since Twenty Twelve 1.0
  */
-function twentytwelve_widgets_init() {
+function mitlib_widgets_init() {
 	register_sidebar( array(
 		'name' => __( 'Main Sidebar', 'twentytwelve' ),
 		'id' => 'sidebar-1',
@@ -314,8 +314,17 @@ function twentytwelve_widgets_init() {
 		'before_title' => '<h3 class="widget-title">',
 		'after_title' => '</h3>',
 	) );
+
+	register_sidebar( array(
+		'name' => __( 'Masthead Search Bar', 'twentytwelve' ),
+		'id' => 'sidebar-search',
+		'description' => __( 'Appears under the MIT Libraries masthead, and houses the search interface', 'twentytwelve' ),
+		'before_title' => '<h3 class="widget-title">',
+		'after_title' => '</h3>',
+		'class' => '',
+	) );
 }
-add_action( 'widgets_init', 'twentytwelve_widgets_init' );
+add_action( 'widgets_init', 'mitlib_widgets_init' );
 
 if ( ! function_exists( 'twentytwelve_content_nav' ) ) :
 /**

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -8,8 +8,15 @@
 
 	get_header( 'home' );
 
-	get_template_part( 'inc/search' );
-?>
+
+if ( is_active_sidebar( 'sidebar-search' ) ) : ?>
+	<div id="sidebar-search" class="widget-area" role="complementary">
+		<?php dynamic_sidebar( 'sidebar-search' ); ?>
+	</div>
+<?php else :
+		get_template_part( 'inc/search' );
+endif; ?>
+
 	<div class="content-main flex-container libraries-home">
 		<div class="col-1 flex-item">
 			<div class="hours-locations">

--- a/page-search.php
+++ b/page-search.php
@@ -13,8 +13,14 @@
 
 get_header(); ?>
 
+	<?php if ( is_active_sidebar( 'sidebar-search' ) ) : ?>
+		<div id="sidebar-search" class="widget-area" role="complementary">
+			<?php dynamic_sidebar( 'sidebar-search' ); ?>
+		</div>
+	<?php else : ?>
 		<?php get_template_part( 'inc/search' ); ?>
-		
+	<?php endif; ?>
+
 		<?php get_template_part( 'inc/breadcrumbs' ); ?>
 
 		<?php while ( have_posts() ) : the_post(); ?>

--- a/page.php
+++ b/page.php
@@ -26,6 +26,13 @@ else :
 get_header();
 endif;
 ?>
+
+	<?php if ( is_active_sidebar( 'sidebar-search' ) ) : ?>
+		<div id="sidebar-search" class="widget-area" role="complementary">
+			<?php dynamic_sidebar( 'sidebar-search' ); ?>
+		</div>
+	<?php endif; ?>
+
 			<?php if ( in_category( 'shortcrumb' ) ) { ?>
 		<?php get_template_part( 'inc/breadcrumbs', 'noChild' ); ?>
 			<?php } else { ?>


### PR DESCRIPTION
This closes #184

**What:**

- Defines a new `Masthead Search Bar` sidebar, to be used to house the updated plugin-provided search UI.
- Adds the sidebar to three templates: the Home, Seach(sic), and Default template. It does this in such a way that, if empty, the Home and Seach templates show the current search UI as a default. If anything is in the sidebar, then _that_ is displayed instead.

**Why:**

- This lays the groundwork for the future launch of the new search interface, but in a way that allows the change to lay dormant and future theme work to proceed without conflicts.
- Once the new search UI is launched, we will be able to convert that page over to the Default template, and drop the Seach template entirely. Smaller themes FTW!

**Note:**
As an added bonus, this changes the function name `twentytwelve_widgets_init` to a more appropriate `mitlib_widgets_init` in functions.php. We aren't using TwentyTwelve, and shouldn't use that name where possible.