### PR TITLE
Remove augmentation and parsing of V1 API

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -822,28 +822,12 @@ function metabox_order( $order ) {
 
 
 /**
- * Add custom fields to 'post' API endpoint
- *
- * @link https://gist.github.com/rileypaulsen/9b4505cdd0ac88d5ef51
- *
- * @param Object $data The data being added to the post object.
- * @param Object $post The post being augmented.
- * @param String $context Unused.
- */
-function mitlib_api_v1_alter( $data, $post, $context ) {
-	$customMeta = (array) get_fields( $post['ID'] );
-
-	$data['meta'] = array_merge( $data['meta'], $customMeta );
-	return $data;
-}
-
-/**
  * Adds custom fields to 'post' and 'experts' API endpoints
  *
  * @link http://v2.wp-api.org/extending/modifying/
  * @link https://gist.github.com/rileypaulsen/9b4505cdd0ac88d5ef51#gistcomment-1622466
  */
-function mitlib_api_v2_alter() {
+function mitlib_api_alter() {
 	// Add custom fields to posts endpoint.
 	register_rest_field( 'post',
 		'meta',
@@ -892,12 +876,7 @@ function mitlib_api_v2_alter() {
 if ( function_exists( 'register_rest_field' ) ) {
 	// The register_rest_field function was introduced in the v2 API.
 	// If that exists, then we call the function to augment that API.
-	add_action( 'rest_api_init', 'mitlib_api_v2_alter' );
-} else {
-	// If that function does not exist, then we call the old API augmentation.
-	if ( function_exists( 'get_fields' ) ) {
-		add_filter( 'json_prepare_post', 'mitlib_api_v1_alter', 10, 3 );
-	}
+	add_action( 'rest_api_init', 'mitlib_api_alter' );
 }
 
 /**

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -61,44 +61,7 @@ function setClosable(alert_ID) {
 	});
 }
 
-function showAlertsV1(json) {
-	var alert_posts_arr = [],
-		alert_ID,
-		alert_template;
-
-	alert_posts_arr = filterAlerts(json)
-
-	// If there is an alert post
-	if (alert_posts_arr.length) {
-
-		// Check for empty title
-		if ('' === alert_posts_arr[0].title) {
-			alert_posts_arr[0].title = 'Alert!';
-		}
-
-		// Alert post ID
-		alert_ID = alert_posts_arr[0].id;
-
-		// Alert HTML template
-		alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
-			'<div class="post alert--critical flex-container">' +
-				'<i class="icon-exclamation-sign" aria-hidden="true"></i>' +
-				'<div class="content-post alertText">' +
-					'<h3>' + alert_posts_arr[0].title + '</h3> ' + alert_posts_arr[0].content +
-				'</div>' +
-			'</div>' +
-		'</div>';
-
-		renderAlert(alert_template,alert_ID);
-
-		// If this is a closable alert
-		if (true === alert_posts_arr[0].meta.closable) {
-			setClosable(alert_ID);
-		}
-	}
-}
-
-function showAlertsV2(json) {
+function showAlerts(json) {
 	var alert_posts_arr = [],
 		alert_ID,
 		alert_template;
@@ -136,16 +99,12 @@ function showAlertsV2(json) {
 }
 
 $(function(){
-	// This is a temporary construct to make transitioning between API endpoints seamless.
-	// It tries the v1 endpoint first, and if that fails then falls back to the v2 endpoint.
-	$.getJSON('/wp-json/posts')
+
+	// This retrieves a list of posts, with additional parsing to determine if
+	// any are displayable alerts.
+	$.getJSON('/wp-json/wp/v2/posts')
 		.done(function(data){
-			showAlertsV1(data);
-		})
-		.fail(function(){
-			$.getJSON('/wp-json/wp/v2/posts')
-				.done(function(data){
-					showAlertsV2(data);
-				});
+			showAlerts(data);
 		});
+
 });

--- a/js/experts-home.js
+++ b/js/experts-home.js
@@ -21,67 +21,8 @@ function shuffleExperts(data) {
 	return data;
 }
 
-// This parses the data structure returned by the V1 API
-function parseExpertsV1(data) {
-
-	// Expert names
-	var expertName1 = data[0].title;
-	var expertName2 = data[1].title;
-	var expertName3 = data[2].title;
-	var expertName4 = data[3].title;
-
-	// Expert images
-	var expertPhoto1 = data[0].featured_image.source;
-	var expertPhoto2 = data[1].featured_image.source;
-	var expertPhoto3 = data[2].featured_image.source;
-	var expertPhoto4 = data[3].featured_image.source;
-
-	// Expert job titles (post excerpts)
-	var expertExcerpt1 = data[0].excerpt;
-	var expertExcerpt2 = data[1].excerpt;
-	var expertExcerpt3 = data[2].excerpt;
-	var expertExcerpt4 = data[3].excerpt;
-
-	// Expert URL (currently an ACF field)
-	var expertURL1 = data[0].meta.expert_url;
-	var expertURL2 = data[1].meta.expert_url;
-	var expertURL3 = data[2].meta.expert_url;
-	var expertURL4 = data[3].meta.expert_url;
-
-	// Append extra markup only if JSON request successful
-	$('.expert').append('<a class="link-profile no-underline">');
-	// Append expert image div
-	$('.expert .link-profile').append('<img alt="" class="expert-photo">');
-	// Append empty spans for expert names
-	$('.expert .link-profile').append('<span class="name"></span>');
-	// Append empty spans for expert titles
-	$('.expert .link-profile').append('<span class="title-job"></span>');
-	// Add expert name to appropriate span
-	$('.expert .name:eq(0)').text(expertName1);
-	$('.expert .name:eq(1)').text(expertName2);
-	$('.expert .name:eq(2)').text(expertName3);
-	$('.expert .name:eq(3)').text(expertName4);
-	// Add image URL to src attribute
-	$('.expert .expert-photo:eq(0)').attr('src', expertPhoto1);
-	$('.expert .expert-photo:eq(1)').attr('src', expertPhoto2);
-	$('.expert .expert-photo:eq(2)').attr('src', expertPhoto3);
-	$('.expert .expert-photo:eq(3)').attr('src', expertPhoto4);
-	// Add expert excerpt
-	$('.expert .title-job:eq(0)').html(expertExcerpt1);
-	$('.expert .title-job:eq(1)').html(expertExcerpt2);
-	$('.expert .title-job:eq(2)').html(expertExcerpt3);
-	$('.expert .title-job:eq(3)').html(expertExcerpt4);
-	// Add expert URL
-	$('.expert .link-profile:eq(0)').attr('href', expertURL1);
-	$('.expert .link-profile:eq(1)').attr('href', expertURL2);
-	$('.expert .link-profile:eq(2)').attr('href', expertURL3);
-	$('.expert .link-profile:eq(3)').attr('href', expertURL4);
-	// Add the expert count to the "All Experts" button
-	$('.view-experts .count').text(data.length);
-}
-
-// This parses the data structure returned by the V2 API
-function parseExpertsV2(data) {
+// This parses the data structure returned by the WordPress API
+function parseExperts(data) {
 
 	// Expert names
 	var expertName1 = data[0].title.rendered;
@@ -141,19 +82,11 @@ function parseExpertsV2(data) {
 
 $(function(){
 	
-	// This is a temporary construct to make transitioning between API endpoints seamless.
-	// It tries the v1 endpoint first, and if that fails then falls back to the v2 endpoint.
 	// Much of this could be eliminated by just loading this URL:
 	// /wp-json/wp/v2/experts?filter[orderby]=rand&filter[posts_per_page]=4
-	$.getJSON('/wp-json/posts?type=experts')
+	$.getJSON('/wp-json/wp/v2/experts?per_page=99')
 		.done(function(data){
-			parseExpertsV1(shuffleExperts(data));
-		})
-		.fail(function(){
-			$.getJSON('/wp-json/wp/v2/experts?per_page=99')
-				.done(function(data){
-					parseExpertsV2(shuffleExperts(data));
-				});
+			parseExperts(shuffleExperts(data));
 		});
 
 });


### PR DESCRIPTION
Now that we've upgraded to WP 4.7.x, there's no longer any need to check for, augment, or do anything else with the V1 API endpoints.

This will close #188 