### PR TITLE
Fix small home display bugs

### DIFF
--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -24,11 +24,12 @@
 			}
 		}
 		.col-2 {
-			border-left: 1px solid $color-secondary;
+			border-left: none;
 			@include bp-tablet--portrait {
 				margin-left: 0; // Creates full bleed
 				width: 67.915%; // Corrects grid for zero margin
 				-ms-flex: 0 1 auto; // Corrects IE10 bug
+				border-left: 1px solid $color-secondary;
 			}
 		}
 	}
@@ -120,6 +121,7 @@
 			}
 		}
 		.location {
+			position: relative;
 			color: #111;
 			font-weight: 300;
 			padding: 0;
@@ -199,6 +201,7 @@
 				margin-left: 1em;
 				position: absolute;
 				right: 0.25em;
+				top: 35%;
 				@include bp-tablet--portrait {
 					content: url(#{$imagesPath}/phone-sfw.svg);
 					position: relative;


### PR DESCRIPTION
This PR fixes 2 small home display bugs on mobile: (1) align phone icon to center of location element, (2) remove left line on News and Experts area. Fixes #191 