### PR TITLE
add bento link to blue search bar

### DIFF
--- a/css/partials/_search.scss
+++ b/css/partials/_search.scss
@@ -428,6 +428,22 @@
 	}
 }
 
+.bento-beta {
+	position: absolute;
+	top: 15px;
+	right: 15px;
+	color: #fff;
+	font-size: 12px;
+
+	&:after {
+		content: ' » ';
+	}
+
+	&:hover {
+		color: #fff;
+	}
+}
+
 .no-js {
 	.search--lib-resources {
 		align-items: flex-start;

--- a/inc/search.php
+++ b/inc/search.php
@@ -23,6 +23,7 @@
 			<a href="/worldcat">WorldCat</a>
 			<a href="/reserves">Course reserves</a>
 			<a href="/about/site-search">Site search</a>
+			<a href="https://lib.mit.edu">Try our new search</a>
 		</div>
 	</div>
 	<div class="wrap-select--resources no-js-hidden">
@@ -143,4 +144,5 @@
 	<a href="https://libraries.mit.edu/barton-advanced" class="search-advanced barton no-js-hidden">Go to Barton advanced search</a>
 	<a href="https://mit.worldcat.org/advancedsearch" class="search-advanced worldcat no-js-hidden">Go to WorldCat advanced search</a>
 	<a href="https://libraries.mit.edu/barton-reserves" class="search-advanced course-reserves no-js-hidden">Go to Course Reserves advanced search</a>
+	<a class="bento-beta no-js-hidden" href="https://lib.mit.edu">Try our new search</a>
 </div><!-- end div.search-main -->


### PR DESCRIPTION
This PR adds a link to the bento beta in the upper right of the blue search bar on the homepage and the search page. 