### PR TITLE
Updates TrackEvent function to use new analytics.js syntax; closes #204

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.5.4-@@branch-@@commit
+Version: 1.5.5-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/functions.php
+++ b/functions.php
@@ -110,17 +110,17 @@ function twentytwelve_scripts_styles() {
 
 	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri() );
 
-	wp_register_style( 'libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array( 'twentytwelve-style', 'font-open-sans' ), '2.2.0' );
+	wp_register_style( 'libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array( 'twentytwelve-style', 'font-open-sans' ), '1.5.5' );
 
 	wp_enqueue_style( 'libraries-global' );
 
-	wp_register_style( 'get-it', get_template_directory_uri() . '/css/build/minified/get-it.min.css', array( 'libraries-global' ), '1.0' );
+	wp_register_style( 'get-it', get_template_directory_uri() . '/css/build/minified/get-it.min.css', array( 'libraries-global' ), '1.5.5' );
 
 	wp_register_style( 'hours-mobile', get_template_directory_uri() . '/css/hours-mobile.css', false, null, 'all' );
 
 	wp_register_style( 'hours-gldatepicker', get_template_directory_uri() . '/libs/datepicker/styles/glDatePicker.default.css', false, null, 'all' );
 
-	wp_register_style( 'hours', get_template_directory_uri() . '/css/build/minified/hours.min.css', array( 'libraries-global', 'hours-mobile', 'hours-gldatepicker' ), '1.0' );
+	wp_register_style( 'hours', get_template_directory_uri() . '/css/build/minified/hours.min.css', array( 'libraries-global', 'hours-mobile', 'hours-gldatepicker' ), '1.5.5' );
 
 	wp_register_style( 'bootstrapCSS', get_stylesheet_directory_uri() . '/css/bootstrap.css', 'false', '', false );
 
@@ -149,17 +149,17 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'modernizr', get_template_directory_uri() . '/js/modernizr.js', array(), '2.8.1', false );
 
-	wp_register_script( 'homeJS', get_template_directory_uri() . '/js/build/home.min.js', array( 'jquery', 'modernizr' ), '2.2.0', true );
+	wp_register_script( 'homeJS', get_template_directory_uri() . '/js/build/home.min.js', array( 'jquery', 'modernizr' ), '1.5.5', true );
 
-	wp_register_script( 'productionJS', get_template_directory_uri() . '/js/build/production.min.js', array( 'jquery' ), '2.2.0', true );
+	wp_register_script( 'productionJS', get_template_directory_uri() . '/js/build/production.min.js', array( 'jquery' ), '1.5.5', true );
 
 	wp_register_script( 'hours-gldatepickerJS', get_template_directory_uri() . '/libs/datepicker/glDatePicker.min.js', false, null, true );
 
-	wp_register_script( 'hoursJS', get_template_directory_uri() . '/js/build/hours.min.js', array( 'jquery', 'productionJS', 'hours-gldatepickerJS' ), '20140312', true );
+	wp_register_script( 'hoursJS', get_template_directory_uri() . '/js/build/hours.min.js', array( 'jquery', 'productionJS', 'hours-gldatepickerJS' ), '1.5.5', true );
 
-	wp_register_script( 'searchJS', get_template_directory_uri() . '/js/build/search.min.js', array( 'jquery', 'modernizr' ), '20140811', false );
+	wp_register_script( 'searchJS', get_template_directory_uri() . '/js/build/search.min.js', array( 'jquery', 'modernizr' ), '1.5.5', false );
 
-	wp_register_script( 'mapJS', get_template_directory_uri() . '/js/build/map.min.js', array( 'jquery' ), '20140813', true );
+	wp_register_script( 'mapJS', get_template_directory_uri() . '/js/build/map.min.js', array( 'jquery' ), '1.5.5', true );
 
 	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?sensor=false', array(), false, true );
 

--- a/js/ga_discovery.js
+++ b/js/ga_discovery.js
@@ -220,7 +220,13 @@ function InitAnalytics(){
 }
 
 function TrackEvent(Category,Action,Label,Value){
-	_gaq.push(['_trackEvent', Category, Action, Label, Value]);
+	ga('send', {
+		hitType: 'event',
+		eventCategory: Category,
+		eventAction: Action,
+		eventLabel: Label,
+		eventValue: Value
+	});
 	// alert('Click tracked: C'+Category+' _ A'+Action+' _ L'+Label+' _ V'+Value);
 }
 

--- a/js/ga_links.js
+++ b/js/ga_links.js
@@ -11,8 +11,13 @@ $(function() {
 		var linkInfo = 'mega-nav_sub_' + linkText + '_' + linkHref;
 		TrackEvent('link', 'click', linkInfo, 1);
 	});
-	function TrackEvent(Category,Action,Label, Value){
-		_gaq.push(['_trackEvent', Category, Action, Label, Value]);
+	function TrackEvent(Category,Action,Label,Value){
+		ga('send', {
+			hitType: 'event',
+			eventCategory: Category,
+			eventAction: Action,
+			eventLabel: Label,
+			eventValue: Value
+		});
 	}
 });
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type" : "git",
     "url" : "https://github.com/mitlibraries/mitlibraries-parent.git"
   },
-  "version": "2.2.0",
+  "version": "1.5.5",
   "devDependencies": {
     "glob": "~3.2.8",
     "grunt": "^0.4.5",

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.5.4-@@branch-@@commit
+Version: 1.5.5-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
I _think_ this will close #204, and restore our ability to record analytics. I know we focused on the front page searches, but the link-tracking page `ga_links.js` had the same syntax - so I've changed that as well.

I'll deploy this to libraries-dev and libraries-test, and report back here when the events start to flow again.