### PR TITLE
Update exclusion list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ language: php
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
-  # aliased to a recent 5.5.x version
-  # "5.5"
-  # aliased to a recent 5.4.x version
-  - "5.4"
+  # aliased to a recent 7.1.x version
+  - "7.1"
+  # aliased to a recent 5.6.x version
+  - "5.6"
   # aliased to a recent 5.3.x version
   - "5.3"
   # Current $required_php_version for WordPress: 5.2.4
@@ -25,23 +25,20 @@ env:
   # Trunk
   # @link https://github.com/WordPress/WordPress
   # WP_VERSION=master WP_MULTISITE=0
-  # WP_VERSION=master WP_MULTISITE=1
-  # WordPress 4.5
-  # @link https://github.com/WordPress/WordPress/tree/4.5-branch
-  # WP_VERSION=4.5 WP_MULTISITE=0
-  - WP_VERSION=4.5 WP_MULTISITE=1
-  # WordPress 4.4
-  # @link https://github.com/WordPress/WordPress/tree/4.4-branch
-  # WP_VERSION=4.4 WP_MULTISITE=0
-  - WP_VERSION=4.4 WP_MULTISITE=1
+  - WP_VERSION=master WP_MULTISITE=1
+  # WordPress 4.7
+  # @link https://github.com/WordPress/WordPress/tree/4.7-branch
+  # WP_VERSION=4.7 WP_MULTISITE=0
+  - WP_VERSION=4.7 WP_MULTISITE=1
 
 # Declare "future" releases to be acceptable failures.
 # @link https://buddypress.trac.wordpress.org/ticket/5620
 # @link http://docs.travis-ci.com/user/build-configuration/
 matrix:
   allow_failures:
-    - php: "5.4"
-    - env: WP_VERSION=4.5 WP_MULTISITE=1
+    - php: "7.1"
+    - php: "5.6"
+    - env: WP_VERSION=master WP_MULTISITE=1
   fast_finish: true
 
 # Use this to prepare the system to install prerequisites or dependencies.
@@ -90,8 +87,9 @@ before_script:
 # Default is specific to project language.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
-  # Search for PHP syntax errors.
-  - find . \( -name '*.php' \) -exec php -lf {} \;
+  # Search for PHP syntax errors outside the libs directory
+  # @link http://stackoverflow.com/questions/4210042/exclude-directory-from-find-command
+  - find . -path ./libs -prune -o \( -name '*.php' \) -exec php -lf {} \;
   # WordPress Coding Standards
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
   # @link http://pear.php.net/package/PHP_CodeSniffer/

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -28,7 +28,10 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamName" />
 		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
 		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfter" />
+		<exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
 		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.StringNotSnakeCase" />
@@ -37,12 +40,12 @@
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized" />
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput.MissingUnslash" />
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotValidated" />
-		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page" />
+		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page" />
 		<exclude name="WordPress.VIP.RestrictedFunctions.error_log" />
 		<exclude name="WordPress.VIP.RestrictedFunctions.get_pages" />
-		<exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog" />
-		<exclude name="WordPress.VIP.OrderByRand.orderby" />
-		<exclude name="WordPress.VIP.TimezoneChange.date_default_timezone_set" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog" />
+		<exclude name="WordPress.VIP.OrderByRand.orderby_orderby" />
+		<exclude name="WordPress.VIP.TimezoneChange.timezone_change_date_default_timezone_set" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedScript" />
 		<exclude name="WordPress.WP.I18n.MissingSingularPlaceholder" />


### PR DESCRIPTION
This closes #196 by updating the list of PHPCS exclusions. This is necessary because PHPCS recently changed how it specifies certain checks, so our old exclusion list is no longer accurate.

Also, this updates what versions of PHP and Wordpress we check for in Travis, and cleans up the file linting process a bit.

Tagging @hllavina as the starting point for a conversation (review if you like, but don't feel obligated to yet), and @frrrances as an FYI