### PR TITLE
Make link to bento more obvious

### DIFF
--- a/css/partials/_search.scss
+++ b/css/partials/_search.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	flex-wrap: nowrap;
 	justify-content: center;
-	padding: 3em 0.5em !important;
+	padding: 3em 0.5em 4em 0.5em!important;
 	position: relative;
 	@include gradient-blue;
 	z-index: map-get($zindex, main);
@@ -306,7 +306,7 @@
 		}
 	}
 	.search-advanced {
-		bottom: 1rem;
+		bottom: 2.5rem;
 		display: none;
 		font-size: 0.75em;
 		font-weight: 300;
@@ -324,7 +324,7 @@
 			}
 			// Magic numbers.
 			&.bartonplus.active {
-				right: 218px;
+				right: 205px;
 			}
 			&.barton.active {
 				right: 187px;
@@ -428,19 +428,32 @@
 	}
 }
 
-.bento-beta {
+.wrap-bento-beta {
 	position: absolute;
-	top: 15px;
-	right: 15px;
-	color: #fff;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	background-color: #9c3273;
+	padding: 5px 15px;
+	color: #E5CEDC;
 	font-size: 12px;
+	font-weight: 600;
+	text-align: right;
 
-	&:after {
-		content: ' » ';
+	p {
+		margin-bottom: 0 !important;
 	}
 
-	&:hover {
+	.bento-beta-link {
 		color: #fff;
+
+		&:after {
+			content: ' » ';
+		}
+
+		&:hover {
+			color: #fff;
+		}
 	}
 }
 

--- a/inc/search.php
+++ b/inc/search.php
@@ -23,7 +23,7 @@
 			<a href="/worldcat">WorldCat</a>
 			<a href="/reserves">Course reserves</a>
 			<a href="/about/site-search">Site search</a>
-			<a href="https://lib.mit.edu">Try our new search</a>
+			<a href="https://lib.mit.edu">It's coming in June! Try our new search early</a>
 		</div>
 	</div>
 	<div class="wrap-select--resources no-js-hidden">
@@ -144,5 +144,7 @@
 	<a href="https://libraries.mit.edu/barton-advanced" class="search-advanced barton no-js-hidden">Go to Barton advanced search</a>
 	<a href="https://mit.worldcat.org/advancedsearch" class="search-advanced worldcat no-js-hidden">Go to WorldCat advanced search</a>
 	<a href="https://libraries.mit.edu/barton-reserves" class="search-advanced course-reserves no-js-hidden">Go to Course Reserves advanced search</a>
-	<a class="bento-beta no-js-hidden" href="https://lib.mit.edu">Try our new search</a>
+	<div class="wrap-bento-beta no-js-hidden">
+		<p>It's coming in June! <a class="bento-beta-link" href="https://lib.mit.edu">Try our new search early</a></p>
+	</div>
 </div><!-- end div.search-main -->


### PR DESCRIPTION
This PR makes the link to the bento on the homepage more obvious for the last month before we make the bento the default.

<img width="1042" alt="screen shot 2017-05-04 at 10 46 47 am" src="https://cloud.githubusercontent.com/assets/4327102/25709341/1505991c-30b7-11e7-9030-05d745d65dd1.png">
