### PR TITLE
Reverts PHPCS back to 2.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ before_script:
   - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
   # Hop into CodeSniffer directory.
   - cd php-codesniffer
+  # Checkout pre 3.x version
+  - git checkout tags/2.9.0
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
   - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards


### PR DESCRIPTION
This lets PHPCS run again, although doing so has revealed a few code problems that either snuck in recently or are the result of implementing stricter standards.

IMO, the problems revealed by this fix should be fixed in a separate branch - but I'm open to differing views on this? Should I go ahead and fix these bugs on this branch? They all seem to be repairable with automated tools.

```
PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
----------------------------------------------------------------------
    SOURCE                                                       COUNT
----------------------------------------------------------------------
[x] Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed            100
[x] WordPress.Arrays.ArrayIndentation.ItemNotAligned             34
[x] WordPress.Arrays.ArrayIndentation.CloseBraceNotAligned       11
[x] WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed    6
----------------------------------------------------------------------
A TOTAL OF 151 SNIFF VIOLATIONS WERE FOUND IN 4 SOURCES
```