### PR TITLE
Removes undefined variable from hours template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ logs
 results
 _notes
 
+.grunt
+
 npm-debug.log
 
 .sass-cache

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,8 +41,8 @@ module.exports = function(grunt) {
   // The default task performs all three phases.
   grunt.registerTask('default', ['javascript', 'styles', 'release']);
 
-  // Code analysis is handled via PHP_CodeSniffer
-  grunt.registerTask('analyze', ['phpcs']);
+  // Code analysis is handled via PHP_CodeSniffer for PHP and Jasmine for Javascript
+  grunt.registerTask('analyze', ['phpcs', 'jasmine']);
 
   // Moved to the tasks folder:
   // grunt.registerTask('dev', ['connect', 'watch']);

--- a/js/specs/demoSpec.js
+++ b/js/specs/demoSpec.js
@@ -1,0 +1,5 @@
+describe("Demonstration suite", function() {
+    it("contains spec with an expectation", function() {
+        expect(true).toBe(true);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-cssmin": "~0.9.0",
     "grunt-contrib-imagemin": "~0.5.0",
+    "grunt-contrib-jasmine": "~0.8.2",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-sass": "~0.7.2",
     "grunt-contrib-uglify": "~0.4.0",

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -309,7 +309,7 @@ $mapPage = '/locations/#!';
 		$next = '';
 	  }
 	?>
-		  <td data-day="<?php echo $i; ?>" class="<?php echo $class . $firstDay; ?>" data-foo="bar"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
+		  <td data-day="<?php echo $i; ?>" class="<?php echo $class; ?>" data-foo="bar"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
 		  <?php } ?>
 		</tr>
 		<?php wp_reset_postdata();
@@ -478,7 +478,7 @@ $class = $next;
 $next = '';
 }
 ?>
-		<td data-day="<?php echo $i; ?>" class="<?php echo $class . $firstDay; ?> noPadding"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
+		<td data-day="<?php echo $i; ?>" class="<?php echo $class; ?> noPadding"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
 		<?php } ?>
 	  </tr>
 	   <?php wp_reset_postdata();  ?>

--- a/tasks/options/jasmine.js
+++ b/tasks/options/jasmine.js
@@ -1,0 +1,8 @@
+module.exports = {
+  jasmine: {
+    src: 'js/*.js',
+    options: {
+      specs: 'js/specs/*.js'
+    }
+  }
+};


### PR DESCRIPTION
This bug is currently responsible for ~14,000 log messages a day in debug.log, which is one of the most significant sources.

Somewhere in the past, there was a variable defined on the hours grid named "firstDay" - which was appended to the class attribute on all cells in the hours table. Unfortunately when the logic to set that variable was removed (which is not available in the git history that I can find), the variable was not removed from the display logic.

This PR fixes that problem, removing the undefined variable.