### PR TITLE
Removes undefined firstDay variable

### DIFF
--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -309,7 +309,7 @@ $mapPage = '/locations/#!';
 		$next = '';
 	  }
 	?>
-		  <td data-day="<?php echo $i; ?>" class="<?php echo $class . $firstDay; ?>" data-foo="bar"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
+		  <td data-day="<?php echo $i; ?>" class="<?php echo $class; ?>" data-foo="bar"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
 		  <?php } ?>
 		</tr>
 		<?php wp_reset_postdata();
@@ -478,7 +478,7 @@ $class = $next;
 $next = '';
 }
 ?>
-		<td data-day="<?php echo $i; ?>" class="<?php echo $class . $firstDay; ?> noPadding"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
+		<td data-day="<?php echo $i; ?>" class="<?php echo $class; ?> noPadding"><span class="hidden-non-mobile date-label"><?php echo date( 'D', $curDay ) . '<br/>' . date( 'n/j', $curDay ); ?></span></td>
 		<?php } ?>
 	  </tr>
 	   <?php wp_reset_postdata();  ?>


### PR DESCRIPTION
This bug is responsible for a significant percentage of the messages currently recorded in debug.log.

Somewhere in the past, there was a variable defined in the hours page template named `firstDay`. However the logic to define this variable was removed - but the code to output the variable (as part of the class attribute on table cells in on the hours page) remains.

This change removes the undefined variable, which should prevent the debug log messages without making any change to page functionality.