### PR TITLE
Adds PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/NTI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated plugins, themes, or libraries?
+YES | NO
+
+#### Requires change to deploy process?
+YES | NO


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

**Please note that I've asked for reviews from both Hattie and Frances - I'd like to merge this only if both of you agree with this change.**

#### What does this PR do?
This adds a template that will pre-populate all pull requests with a suggested set of content - which is then edited by the person proposing the change. The goal of the change is to align this project with the process first adopted by the MITLibraries/bento project.

Having a PR template should help make code reviews easier, by ensuring that developers provide the context necessary for reviewers to understand the change.

#### Helpful background context (if appropriate)
With many projects, it is very easy to submit minimal descriptions along with a pull request - which means more back-and-forth conversation and delayed reviews.

#### How can a reviewer manually see the effects of these changes?
Look at the structure of this pull request - which uses the proposed template. If this is sufficiently clear, then we can probably adopt the template. If something seems unclear, then let's discuss and I'll adjust the template.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-132

#### Screenshots (if appropriate)
not applicable

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO