### PR TITLE
Convert links to shortcut URLs

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -12,7 +12,7 @@
 		<div class="links-all flex-container">
 			<div class="flex-item">
 				<h4><a href="/search">Search</a></h4>
-				<a href="https://libraries.mit.edu/quicksearch" class="link-sub">Quick search</a>
+				<a href="/quicksearch" class="link-sub">Quick search</a>
 				<a href="/barton" class="link-sub">Barton catalog</a>
 				<a href="/vera" class="link-sub">Vera: E-journals &amp; databases</a>
 				<a href="/worldcat" class="link-sub">WorldCat</a>
@@ -69,7 +69,7 @@
 						<span class="sr">Twitter</span>
 					</a><!-- End Twitter -->
 					
-					<a href="//libraries.mit.edu/facebook" title="Facebook">
+					<a href="/facebook" title="Facebook">
 						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
 						<span class="sr">Facebook</span>
 					</a><!-- End Facebook -->

--- a/inc/nav-alt.php
+++ b/inc/nav-alt.php
@@ -28,7 +28,7 @@
 						<li><a href="/bartonplus">BartonPlus (mega-search) <span class="about">Articles, e-books, &amp; more</span></a></li>
 						<li><a href="/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
 						<li><a href="/barton">Barton catalog (classic search) <span class="about">Books &amp; more at MIT</span></a></li>
-						<li><a href="http://mit.worldcat.org">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
+						<li><a href="/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
 						<li><a href="/barton-reserves">Course reserves</a></li>
 						<li><a href="/search" class="bottom extra"><span>More search tools & help</span> <span class="about">Images, data, DSpace, etc.</span></a> </li>
 					</ul>
@@ -37,10 +37,10 @@
 					<ul class="multi-column-dropdown  flex-item">
 						<li><h3 class="heading-col">Also try</h3></li>
 						<li><a href="/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-						<li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
+						<li><a href="/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
 						<li><a href="/libx">LibX <span class="about">Search/authenticate via browser</span></a></li>
-						<li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
-						<li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
+						<li><a href="/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
+						<li><a href="/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
 						<li><a href="/about/site-search">Site search</a></li>
 					</ul>
 				  </li>
@@ -80,8 +80,8 @@
 					<ul class="multi-column-dropdown">
 						<li><h3 class="heading-col">Renew, request, suggest</h3></li>
 						<li><a href="/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-						<li><a href="http://library.mit.edu">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-						<li><a href="http://mit.worldcat.org">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+						<li><a href="/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+						<li><a href="/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
 						<li><a href="/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
 						<li><a href="/suggest-purchase">Suggest a purchase</a></li>
 						<li><a href="/borrow" class="bottom">More options &amp; help</a></li>
@@ -91,8 +91,8 @@
 					<ul class="multi-column-dropdown">
 						<li><h3 class="heading-col">More information</h3></li>
 						<li><a href="/getit">Get it <span class="about">Understand your options</span></a></li>
-						<li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-						<li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
+						<li><a href="/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
+						<li><a href="/reserves">Course reserves &amp; TIP FAQ</a></li>
 						<li><a href="/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>                          
 						</ul>
 				  </li>
@@ -115,9 +115,9 @@
 					<ul class="multi-column-dropdown">
 						<li><h3 class="heading-col">Publishing &amp; content management</h3></li>
 						<li><a href="/references">Citation software <span class="about">EndNote, Mendeley, &amp; Zotero</span></a></li>
-						<li><a href="http://libguides.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-						<li><a href="http://libguides.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-						<li><a href="http://libguides.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+						<li><a href="/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
+						<li><a href="/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
+						<li><a href="/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
 						<li><a href="/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>               
 					</ul>
 				  </li>

--- a/inc/nav-main.php
+++ b/inc/nav-main.php
@@ -28,10 +28,10 @@
 		  <div class="col-1 flex-item">
 				<h3 class="heading-col">Start here</h3>
 				<ul class="list-unbulleted">
-					<li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
+					<li><a href="/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
 					<li><a href="/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
 					<li><a href="/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
-					<li><a href="http://mit.worldcat.org">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
+					<li><a href="/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
 					<li><a href="/barton-reserves">Course reserves</a></li>
 					<li><a href="/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
 				</ul>
@@ -40,10 +40,10 @@
 				<h3 class="heading-col">Also try</h3>
 				<ul class="list-unbulleted">
 					<li><a href="/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-					<li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
+					<li><a href="/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
 					<li><a href="/libx">LibX <span class="about">Search/authenticate via browser</span></a></li>
-					<li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
-					<li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
+					<li><a href="/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
+					<li><a href="/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
 					<li><a href="/about/site-search">Site search</a></li>
 				</ul>
 		  </div>
@@ -92,8 +92,8 @@
 				<h3 class="heading-col">Renew, request, suggest</h3>
 				<ul class="list-unbulleted">
 					<li><a href="/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-					<li><a href="http://library.mit.edu">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-					<li><a href="http://mit.worldcat.org">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+					<li><a href="/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+					<li><a href="/worlcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
 					<li><a href="/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
 					<li><a href="/suggest-purchase">Suggest a purchase</a></li>
 					<li><a href="/borrow" class="bottom">More options &amp; help</a></li>
@@ -103,8 +103,8 @@
 				<h3 class="heading-col">More information</h3>
 				<ul class="list-unbulleted">
 					<li><a href="/getit">Get it <span class="about">Understand your options</span></a></li>
-					<li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-					<li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
+					<li><a href="/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
+					<li><a href="/reserves">Course reserves &amp; TIP FAQ</a></li>
 					<li><a href="/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
 				</ul>
 		  </div>
@@ -131,9 +131,9 @@
 				<h3 class="heading-col">Publishing &amp; content management</h3>
 				<ul class="list-unbulleted">
 					<li><a href="/references">Citation software <span class="about">EndNote, Mendeley, &amp; Zotero</span></a></li>
-					<li><a href="http://libguides.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-					<li><a href="http://libguides.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-					<li><a href="http://libguides.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+					<li><a href="/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
+					<li><a href="/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
+					<li><a href="/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
 					<li><a href="/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
 				</ul>
 		  </div>

--- a/inc/search.php
+++ b/inc/search.php
@@ -23,7 +23,7 @@
 			<a href="/worldcat">WorldCat</a>
 			<a href="/reserves">Course reserves</a>
 			<a href="/about/site-search">Site search</a>
-			<a href="https://libraries.mit.edu/quicksearch">It's coming in June! Try our new search early</a>
+			<a href="/quicksearch">It's coming in June! Try our new search early</a>
 		</div>
 	</div>
 	<div class="wrap-select--resources no-js-hidden">
@@ -140,11 +140,11 @@
 			<option value="keyword" selected="selected">Keyword</option>
 		</select>
 	</div>
-	<a href="https://libraries.mit.edu/bartonplus-advanced" class="search-advanced bartonplus active no-js-hidden">Go to BartonPlus advanced search</a>
-	<a href="https://libraries.mit.edu/barton-advanced" class="search-advanced barton no-js-hidden">Go to Barton advanced search</a>
+	<a href="/bartonplus-advanced" class="search-advanced bartonplus active no-js-hidden">Go to BartonPlus advanced search</a>
+	<a href="/barton-advanced" class="search-advanced barton no-js-hidden">Go to Barton advanced search</a>
 	<a href="https://mit.worldcat.org/advancedsearch" class="search-advanced worldcat no-js-hidden">Go to WorldCat advanced search</a>
-	<a href="https://libraries.mit.edu/barton-reserves" class="search-advanced course-reserves no-js-hidden">Go to Course Reserves advanced search</a>
+	<a href="/barton-reserves" class="search-advanced course-reserves no-js-hidden">Go to Course Reserves advanced search</a>
 	<div class="wrap-bento-beta no-js-hidden">
-		<p>It's coming in June! <a class="bento-beta-link" href="https://libraries.mit.edu/quicksearch">Try our new search early</a></p>
+		<p>It's coming in June! <a class="bento-beta-link" href="/quicksearch">Try our new search early</a></p>
 	</div>
 </div><!-- end div.search-main -->


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

Please note: The Travis failure is being caused by unrelated code problems in the hours page. I'm working up a separate PR to address those. If desired, we can merge that work and then consider this from a clean starting point.

#### What does this PR do?
This converts hard-coded link URLs in the theme to use shortcut URLs whereever possible. Most of these changes are found in the main navigation, but some are in the footer and search template.

#### How can a reviewer manually see the effects of these changes?
Code inspection of this PR, and comparing the production site markup with dev site markup after a deploy. I'll assemble a list of reference URLs that show the differences...

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-159

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
