### PR TITLE
Fixes whitespace problems

### DIFF
--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -60,7 +60,6 @@
 		<exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog" />
 		<exclude name="WordPress.VIP.OrderByRand.orderby_orderby" />
 		<exclude name="WordPress.VIP.TimezoneChange.timezone_change_date_default_timezone_set" />
-		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedScript" />
 		<exclude name="WordPress.WP.I18n.MissingSingularPlaceholder" />

--- a/functions.php
+++ b/functions.php
@@ -589,7 +589,7 @@ function getRoot( $post ) {
 		}
 	}
 
-	$max = count( $ar ) -1;
+	$max = count( $ar ) - 1;
 
 	if ( $max == -1 ) {
 		return $post->ID;

--- a/lib/hours.php
+++ b/lib/hours.php
@@ -908,7 +908,7 @@ function semesterNameToId( $name, $locationId ) {
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
 
 	if ( $semList->have_posts() ) {
-		$semList -> the_post();
+		$semList->the_post();
 
 		return get_the_ID();
 
@@ -988,7 +988,7 @@ function locationNameToId( $name ) {
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
 
 	if ( $locationList->have_posts() ) {
-		$locationList -> the_post();
+		$locationList->the_post();
 
 		return get_the_ID();
 
@@ -1017,7 +1017,7 @@ function locationNameToIdOriginal( $name ) {
 	remove_filter( 'posts_where', 'title_filter', 10, 2 );
 
 	if ( $locationList->have_posts() ) {
-		$locationList -> the_post();
+		$locationList->the_post();
 		$id = get_post_meta( get_the_ID(), 'associated_location', true );
 
 		return $id;

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -33,7 +33,7 @@ $dtWeekday = date( 'N', $dt );
 
 ?>
 <script>
-	todayDate = new Date(<?php echo $dtYear; ?>,<?php echo ($dtMo -1); ?>,<?php echo $dtDay; ?>);
+	todayDate = new Date(<?php echo $dtYear; ?>,<?php echo ($dtMo - 1); ?>,<?php echo $dtDay; ?>);
 </script>
 <?php
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This fixes a problem recently uncovered in the `lib/hours.php` file by an update to the coding standard library. While fixing this, I also removed a whitelist entry for another whitespace violation and fixed the two incidences of that violation.

#### Helpful background context (if appropriate)
n/a

#### How can a reviewer manually see the effects of these changes?
There should be no visible outcome from these changes. The affected pages would be the hours display, specifically the javascript-powered date navigation.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-173

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
