### PR TITLE
Bumps theme version to 1.6.0

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.5.6-@@branch-@@commit
+Version: 1.6.0-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.5.6-@@branch-@@commit
+Version: 1.6.0-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This bumps the theme version to 1.6.0 in preparation for a pending tagged release and deploy.

Please note - there are failures in Travis due to some code problems that exist separate from this change. There is a separate branch ( MITLibraries/MITlibraries-parent#231 ) that addresses these problems.

#### Helpful background context (if appropriate)
It has been a while since we've formally released a new version of the theme.

#### How can a reviewer manually see the effects of these changes?
Check the version string on a tier where this branch has been deployed.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-181

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
