### PR TITLE
Fix WPCS to the master branch, not develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,7 @@ before_script:
   # Create WordPress database.
   - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
   # Install WordPress Coding Standards (master branch, not develop).
-  - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
-  - cd wordpress-coding-standards
-  - git checkout master
-  - cd ..
+  - git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
   # Install CodeSniffer for WordPress Coding Standards checks (pre 3.x version).
   - git clone https://github.com/squizlabs/PHP_CodeSniffer.git php-codesniffer
   - cd php-codesniffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,14 @@ before_script:
   - sed -i "s/yourpasswordhere//" wp-tests-config.php
   # Create WordPress database.
   - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - git clone https://github.com/squizlabs/PHP_CodeSniffer.git php-codesniffer
-  # Install WordPress Coding Standards.
+  # Install WordPress Coding Standards (master branch, not develop).
   - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
-  # Hop into CodeSniffer directory.
+  - cd wordpress-coding-standards
+  - git checkout master
+  - cd ..
+  # Install CodeSniffer for WordPress Coding Standards checks (pre 3.x version).
+  - git clone https://github.com/squizlabs/PHP_CodeSniffer.git php-codesniffer
   - cd php-codesniffer
-  # Checkout pre 3.x version
   - git checkout tags/2.9.1
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941

--- a/comments.php
+++ b/comments.php
@@ -54,7 +54,7 @@ if ( post_password_required() ) {
 		 * But we only want the note on posts and pages that had comments in the first place.
 		 */
 		if ( ! comments_open() && get_comments_number() ) : ?>
-		<p class="nocomments"><?php _e( 'Comments are closed.' , 'twentytwelve' ); ?></p>
+		<p class="nocomments"><?php _e( 'Comments are closed.', 'twentytwelve' ); ?></p>
 		<?php endif; ?>
 
 	<?php endif; // have_comments(). ?>

--- a/content-hour-row.php
+++ b/content-hour-row.php
@@ -97,7 +97,7 @@
 
 													$end = min( $msgEnd, $arDays[6] );
 
-													$diff = floor( ($end - $curDay) / (60 * 60 * 24) ) + 1;
+													$diff = floor( ( $end - $curDay ) / ( 60 * 60 * 24 ) ) + 1;
 
 													$msgClass .= ' msgSpan' . $diff;
 
@@ -169,7 +169,7 @@
 
 										$end = min( $msgEnd, $arDays[6] );
 
-										$diff = floor( ($end - $curDay) / (60 * 60 * 24) ) + 1;
+										$diff = floor( ( $end - $curDay ) / ( 60 * 60 * 24 ) ) + 1;
 
 										$msgClass .= ' msgSpan' . $diff;
 

--- a/functions.php
+++ b/functions.php
@@ -167,13 +167,13 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'term-hours', get_template_directory_uri() . '/js/build/term-hours.min.js', array( 'jquery', 'productionJS' ), false, true );
 
-	wp_register_script( 'moment',     '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/moment.js', false, false, true );
+	wp_register_script( 'moment', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/moment.js', false, false, true );
 
-	wp_register_script( 'tabletop',   '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/tabletop.js', false, false, true );
+	wp_register_script( 'tabletop', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/tabletop.js', false, false, true );
 
 	wp_register_script( 'underscore', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/underscore.js', false, false, true );
 
-	wp_register_script( 'lib-hours',  '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/libhours.js', array( 'moment', 'tabletop', 'underscore' ), false, true );
+	wp_register_script( 'lib-hours', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/libhours.js', array( 'moment', 'tabletop', 'underscore' ), false, true );
 
 	wp_register_script( 'forms', get_template_directory_uri() . '/js/login_functions.js', array(), '1.0.0', false );
 
@@ -650,7 +650,7 @@ function wsf_breadcrumbs( $sep = '/', $label = 'Browsing' ) {
 
 	// Do not show breadcrumbs on home or front pages.
 	// So we will just return quickly.
-	if ( (is_home() || is_front_page()) && ( ! $front_page) ) {
+	if ( ( is_home() || is_front_page() ) && ( ! $front_page ) ) {
 	  return; }
 
 	// Create a constant for the separator, with space padding.
@@ -800,7 +800,7 @@ function one_column_for_all( $option ) {
 
 // Then we add 'submitdiv' on the bottom, by creating this filter with a low priority.
 // It feels a bit like overkill, because it assumes other plug-ins might be using the same filter, but still...
-add_filter( 'get_user_option_meta-box-order_post','submitdiv_at_top', 1, 1 );
+add_filter( 'get_user_option_meta-box-order_post', 'submitdiv_at_top', 1, 1 );
 function submitdiv_at_top( $result ) {
 	$result['normal'] .= 'submitdiv';
 	return $result;

--- a/lib/news.php
+++ b/lib/news.php
@@ -116,7 +116,7 @@ function QueryPoolOne() {
 	$second = get_posts( $args );
 
 	// Merge the two.
-	$items = array_merge( $first,$second );
+	$items = array_merge( $first, $second );
 
 	return $items;
 }
@@ -130,7 +130,7 @@ function RenderPool( $items ) {
 		if ( $item->post_type === 'post' ) {
 			$url = get_permalink( $item->ID );
 		} elseif ( $item->post_type === 'bibliotech' ) {
-			$url = str_replace( '/news/','/news/bibliotech/',get_permalink( $item->ID ) );
+			$url = str_replace( '/news/', '/news/bibliotech/', get_permalink( $item->ID ) );
 		} elseif ( $item->post_type === 'spotlights' ) {
 			$url = $custom['external_link'][0];
 		} else {
@@ -177,8 +177,8 @@ function RenderPool( $items ) {
 		$eventDate = '';
 		if ( $item->post_type === 'post' && array_key_exists( 'is_event', $custom ) ) {
 			if ( $custom['is_event'][0] === '1' ) {
-				$eventDate = DateTime::createFromFormat( 'Ymd',$custom['event_date'][0] );
-				$eventDate = '<div class="date-event"><img alt="calendar icon" src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px" ><span class="event">' . date_format( $eventDate,'F j' ) . '</span>';
+				$eventDate = DateTime::createFromFormat( 'Ymd', $custom['event_date'][0] );
+				$eventDate = '<div class="date-event"><img alt="calendar icon" src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px" ><span class="event">' . date_format( $eventDate, 'F j' ) . '</span>';
 				if ( $custom['event_start_time'][0] != '' ) {
 					$eventDate = $eventDate . '<span class="time-event"> ' . $custom['event_start_time'][0];
 				};
@@ -199,7 +199,7 @@ function RenderPool( $items ) {
 				$image = json_decode( $custom['homeImg'][0] );
 				// We use "original" even though this is already cropped to avoid cropping again.
 				$imageURL = wp_get_attachment_image_src( $image->cropped_image, 'original' );
-				$imageURL = str_replace( '/wp-content/uploads/','/news/files/',$imageURL[0] );
+				$imageURL = str_replace( '/wp-content/uploads/', '/news/files/', $imageURL[0] );
 				$imageElement = '<div class="image" style="background-image: url(' . $imageURL . ')"></div>';
 			}
 		}
@@ -270,7 +270,7 @@ function SummarizePool( $items ) {
 		$type = 'two';
 	} else {
 		// More than one news item - so we flip a coin for type.
-		if ( mt_rand( 0,1 ) ) {
+		if ( mt_rand( 0, 1 ) ) {
 			$type = 'two';
 		} else {
 			$type = 'one';

--- a/page-featured-news.php
+++ b/page-featured-news.php
@@ -57,7 +57,7 @@
 						if ( $custom['homeImg'][0] != '' ) {
 							$image = json_decode( $custom['homeImg'][0] );
 							$imageURL = wp_get_attachment_image_src( $image->cropped_image, 'original' );
-							$imageURL = str_replace( '/wp-content/uploads/','/news/files/',$imageURL[0] );
+							$imageURL = str_replace( '/wp-content/uploads/', '/news/files/', $imageURL[0] );
 							$imageTag = '<img src="' . $imageURL . '" alt="">';
 						}
 					}
@@ -85,8 +85,8 @@
 
 					// Card date.
 					if ( $post->post_type === 'post' && $post->is_event[0] === '1' ) {
-						$eventDate = DateTime::createFromFormat( 'Ymd',$post->event_date );
-						$eventDate = '<span class="date">' . date_format( $eventDate,'F j' ) . '</span>';
+						$eventDate = DateTime::createFromFormat( 'Ymd', $post->event_date );
+						$eventDate = '<span class="date">' . date_format( $eventDate, 'F j' ) . '</span>';
 						if ( $post->event_start_time != '' ) {
 							$eventDate = $eventDate . ' ' . $post->event_start_time;
 						};
@@ -96,8 +96,8 @@
 					}
 
 					echo '<div class="excerpt-news" style="background-color: #ddf;border:1px solid blue;">';
-					echo        '<div class="category-post">' . $label . '</div>';
-					echo        '<div class="href">';
+					echo '    <div class="category-post">' . $label . '</div>';
+					echo '    <div class="href">';
 					if ( $post->post_type === 'post' || $post->post_type === 'bibliotech' ) {
 						the_permalink();
 					} elseif ( $post->post_type === 'spotlights' ) {
@@ -105,20 +105,20 @@
 					} else {
 
 					}
-					echo        '</div>';
+					echo '    </div>';
 					if ( $post->post_type === 'post' && $post->is_event[0] === '1' ) {
 						echo '<div class="datetime">' . $eventDate . '</div>';
 					}
-					echo        '<h3 class="title-post">';
+					echo '    <h3 class="title-post">';
 
 					if ( $custom['homepage_post_title'][0] ) {
 						echo $custom['homepage_post_title'][0];
 					} else {
 						the_title();
 					}
-					echo        '</h3>';
-					echo        $imageTag;
-					echo    '</div>';
+					echo '    </h3>';
+					echo $imageTag;
+					echo '</div>';
 
 					echo '</div>';
 

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -33,7 +33,7 @@ $dtWeekday = date( 'N', $dt );
 
 ?>
 <script>
-	todayDate = new Date(<?php echo $dtYear; ?>,<?php echo ($dtMo - 1); ?>,<?php echo $dtDay; ?>);
+	todayDate = new Date(<?php echo $dtYear; ?>,<?php echo ( $dtMo - 1 ); ?>,<?php echo $dtDay; ?>);
 </script>
 <?php
 

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -14,7 +14,7 @@
 $pageRoot = getRoot( $post );
 $section = get_post( $pageRoot );
 
-$showMap = ($_GET['v'] != '') && ($_GET['v'] == 'map') ? 1 : 0;
+$showMap = ( $_GET['v'] != '' ) && ( $_GET['v'] == 'map' ) ? 1 : 0;
 
 
 

--- a/page.php
+++ b/page.php
@@ -46,7 +46,7 @@ endif;
 			<?php if ( in_category( 'shortcrumb' ) ) { ?>
 			<?php get_template_part( 'inc/self', 'title' ); ?>
 			<?php } elseif ( ! in_category( 'page-root' ) ) { ?>
-			<?php get_template_part( 'inc/content','root' ); ?>
+			<?php get_template_part( 'inc/content', 'root' ); ?>
 			<?php } ?>	
 			
 			<div id="content" class="content <?php if ( is_active_sidebar( 'sidebar-1' ) ) { echo 'has-sidebar';} ?>">

--- a/taxonomy-location-types.php
+++ b/taxonomy-location-types.php
@@ -81,9 +81,9 @@ get_header(); ?>
 						?>
 							<li>
 								<h3><a href="#"><?php echo the_title() ?><i class="icon-arrow-right"></i></a></h3>
-								<?= $phone ?><br/>
+								<?php echo esc_html( $phone ); ?><br/>
 								Open today 9am-5pm by appointment only<br/>
-								<a href="#">Map: <?= $building ?> <i class="icon-arrow-right"></i></a>
+								<a href="#">Map: <?php echo esc_html( $building ); ?> <i class="icon-arrow-right"></i></a>
 							</li>
 						
 						<?php endwhile; // end of the loop. ?>					


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This branch does two things:
1. Implements a somewhat speculative change to how we're loading the WordPress Coding Standards, specifically making sure that Travis checks out the current state of the `master` branch, rather than the default branch - which for some odd reason is `develop`.
2. A set of cleaning steps for existing non-whitelisted problems.

#### Helpful background context (if appropriate)
Our work is somewhat regularly getting flagged for existing problems that are made visible by changes to the WPCS repo. This is an attempt to tame the rate of these changes, giving us more control over how we tackle technical debt.

#### How can a reviewer manually see the effects of these changes?
The change should be mostly visible within Travis and GitHub (passing tests, etc). Visual changes should not be present on a deployed theme.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-205

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
