### PR TITLE
Fixes typo in WorldCat link

### DIFF
--- a/inc/nav-main.php
+++ b/inc/nav-main.php
@@ -93,7 +93,7 @@
 				<ul class="list-unbulleted">
 					<li><a href="/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
 					<li><a href="/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-					<li><a href="/worlcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+					<li><a href="/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
 					<li><a href="/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
 					<li><a href="/suggest-purchase">Suggest a purchase</a></li>
 					<li><a href="/borrow" class="bottom">More options &amp; help</a></li>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This fixes a typo in the main navigation template.

#### How can a reviewer manually see the effects of these changes?
Check the link to WorldCat under Borrow & Request in the main navigation. Currently it is pointing to `/worlcat` instead of `/worldcat`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-213

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
