### PR TITLE
Adds support for MIT Calendar urls in news cards

### DIFF
--- a/lib/news.php
+++ b/lib/news.php
@@ -121,21 +121,34 @@ function QueryPoolOne() {
 	return $items;
 }
 
+/**
+ * This function takes a WordPress post object, inspects the relevant fields,
+ * and returns the appropriate URL for use in the front page card markup.
+ *
+ * @param object $item A WordPress post object.
+ * @param array  $custom An array of custom post values.
+ */
+function build_url( $item, $custom ) {
+	$url = get_permalink( $item->ID );
+	if ( array_key_exists( 'calendar_url', $custom ) ) {
+		if ( 0 < strlen( $custom['calendar_url'][0] ) ) {
+			$url = $custom['calendar_url'][0];
+		}
+	} elseif ( 'bibliotech' === $item->post_type ) {
+		$url = str_replace( '/news/', '/news/bibliotech/', get_permalink( $item->ID ) );
+	} elseif ( 'spotlights' === $item->post_type ) {
+		$url = $custom['external_link'][0];
+	}
+	return $url;
+}
+
 function RenderPool( $items ) {
 	// This takes an input recordset of news items and renders it as HTML.
 	foreach ( $items as $item ) {
 		$custom = get_post_custom( $item->ID );
 
 		// URL.
-		if ( $item->post_type === 'post' ) {
-			$url = get_permalink( $item->ID );
-		} elseif ( $item->post_type === 'bibliotech' ) {
-			$url = str_replace( '/news/', '/news/bibliotech/', get_permalink( $item->ID ) );
-		} elseif ( $item->post_type === 'spotlights' ) {
-			$url = $custom['external_link'][0];
-		} else {
-			$url = '';
-		}
+		$url = build_url( $item, $custom );
 
 		// Label.
 		$label = '<div class="category-post">';

--- a/page-featured-news.php
+++ b/page-featured-news.php
@@ -49,7 +49,7 @@
 					$custom = get_post_custom();
 
 					// URL.
-					$url = get_permalink( $post->id );
+					$url = build_url( $post, $custom );
 
 					// Highlight image - use 17616 for debugging.
 					$imageTag = '';
@@ -97,15 +97,7 @@
 
 					echo '<div class="excerpt-news" style="background-color: #ddf;border:1px solid blue;">';
 					echo '    <div class="category-post">' . $label . '</div>';
-					echo '    <div class="href">';
-					if ( $post->post_type === 'post' || $post->post_type === 'bibliotech' ) {
-						the_permalink();
-					} elseif ( $post->post_type === 'spotlights' ) {
-						echo $custom['external_link'][0];
-					} else {
-
-					}
-					echo '    </div>';
+					echo '    <div class="href">' . esc_url( $url ) . '</div>';
 					if ( $post->post_type === 'post' && $post->is_event[0] === '1' ) {
 						echo '<div class="datetime">' . $eventDate . '</div>';
 					}


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This will make the needed change to the `lib/news.php` to allow news items promoted to the front page to point back to an MIT Calendar URL (which is stored in a new field that the parent theme doesn't know to look for)

#### Helpful background context (if appropriate)
This is a follow-on change from Hattie's work to import news items from the main MIT Calendar.

Of the two files that change here, the most important is `lib/news.php` - which is what builds the news cards themselves. The `page-featured-news.php` provides a staff-facing page that lists all eligible cards for easier debugging. The changes to that page here basically just make sure that template is using the current URL generation code, rather than separate/hacky versions.

Please note: I'm pretty sure that Travis is failing for unrelated reasons (updated coding standards caught pre-existing problems)

#### How can a reviewer manually see the effects of these changes?
Look on the (private) Featured News page, or look at the front page when a relevant news post has been received. The link on this card should point back to the MIT Calendar. The same content will point to a Libraries' News URL without this change.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-228

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
