### PR TITLE
Converts  to use get_site_url() in functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -169,13 +169,13 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'term-hours', get_template_directory_uri() . '/js/build/term-hours.min.js', array( 'jquery', 'productionJS' ), false, true );
 
-	wp_register_script( 'moment', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/moment.js', false, false, true );
+	wp_register_script( 'moment', get_site_url() . '/app/libhours/js/vendor/moment.js', false, false, true );
 
-	wp_register_script( 'tabletop', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/tabletop.js', false, false, true );
+	wp_register_script( 'tabletop', get_site_url() . '/app/libhours/js/vendor/tabletop.js', false, false, true );
 
-	wp_register_script( 'underscore', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/vendor/underscore.js', false, false, true );
+	wp_register_script( 'underscore', get_site_url() . '/app/libhours/js/vendor/underscore.js', false, false, true );
 
-	wp_register_script( 'lib-hours', '//' . $_SERVER['SERVER_NAME'] . '/app/libhours/js/libhours.js', array( 'moment', 'tabletop', 'underscore' ), false, true );
+	wp_register_script( 'lib-hours', get_site_url() . '/app/libhours/js/libhours.js', array( 'moment', 'tabletop', 'underscore' ), false, true );
 
 	wp_register_script( 'forms', get_template_directory_uri() . '/js/login_functions.js', array(), '1.0.0', false );
 

--- a/functions.php
+++ b/functions.php
@@ -169,13 +169,13 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'term-hours', get_template_directory_uri() . '/js/build/term-hours.min.js', array( 'jquery', 'productionJS' ), false, true );
 
-	wp_register_script( 'moment', get_site_url() . '/app/libhours/js/vendor/moment.js', false, false, true );
+	wp_register_script( 'moment', get_site_url( 1 ) . '/app/libhours/js/vendor/moment.js', false, false, true );
 
-	wp_register_script( 'tabletop', get_site_url() . '/app/libhours/js/vendor/tabletop.js', false, false, true );
+	wp_register_script( 'tabletop', get_site_url( 1 ) . '/app/libhours/js/vendor/tabletop.js', false, false, true );
 
-	wp_register_script( 'underscore', get_site_url() . '/app/libhours/js/vendor/underscore.js', false, false, true );
+	wp_register_script( 'underscore', get_site_url( 1 ) . '/app/libhours/js/vendor/underscore.js', false, false, true );
 
-	wp_register_script( 'lib-hours', get_site_url() . '/app/libhours/js/libhours.js', array( 'moment', 'tabletop', 'underscore' ), false, true );
+	wp_register_script( 'lib-hours', get_site_url( 1 ) . '/app/libhours/js/libhours.js', array( 'moment', 'tabletop', 'underscore' ), false, true );
 
 	wp_register_script( 'forms', get_template_directory_uri() . '/js/login_functions.js', array(), '1.0.0', false );
 

--- a/functions.php
+++ b/functions.php
@@ -919,3 +919,15 @@ function ssl_srcset( $sources ) {
 }
 add_filter( 'wp_calculate_image_srcset', 'ssl_srcset' );
 
+/**
+ * Returns a sanitized version of the Shibboleth EPPN value.
+ *
+ * @link https://wiki.shibboleth.net/confluence/display/SHIB/EduPersonPrincipalName
+ */
+function shibboleth_eppn() {
+	$eppn = '';
+	if ( isset( $_SERVER['REDIRECT_eppn'] ) ) {
+		$eppn = sanitize_email( wp_unslash( $_SERVER['REDIRECT_eppn'] ) );
+	}
+	return $eppn;
+}

--- a/page-authenticate.php
+++ b/page-authenticate.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Template Name: Authenticate
@@ -6,72 +5,72 @@
  * @package MIT_Libraries_Parent
  * @since 1.2.1
  */
-get_header(); 
-?>
 
+// Read and treat Shibboleth EPPN value for use in page.
+$eppn = shibboleth_eppn();
+
+get_header();
+?>
 
 <script type="text/javascript" src="/wp-content/themes/libraries/js/login_functions.js"></script>
 <script type="text/javascript">
-function getCookie(name)
-{
-var i,x,y,ARRcookies = document.cookie.split(";");
-for (i = 0;i < ARRcookies.length;i++)
-{
-  x = ARRcookies[i].substr(0,ARRcookies[i].indexOf("="));
-  y = ARRcookies[i].substr(ARRcookies[i].indexOf("=")+1);
-  x = x.replace(/^\s+|\s+$/g,"");
-  if (x == name)
-    {
-    return unescape(y);
-    }
-  }
+function getCookie(name) {
+	var i,x,y,ARRcookies = document.cookie.split(";");
+	for (i = 0;i < ARRcookies.length;i++) {
+		x = ARRcookies[i].substr(0,ARRcookies[i].indexOf("="));
+		y = ARRcookies[i].substr(ARRcookies[i].indexOf("=")+1);
+		x = x.replace(/^\s+|\s+$/g,"");
+		if (x == name) {
+			return unescape(y);
+		}
+	}
 }
 
-	var referer = document.referer;
-	var redirecTo = "";
+var referer = document.referer;
+var redirecTo = "";
 
-	$(document).ready(function() {
-	    if (referer != "" && referer != "undefined") {
-			start = location.href.indexOf("pid");
-	        newlocation = location.href.substr(start);
-			redirecTo = newlocation.substr(newlocation.indexOf("=")+1);
-            eppn = '<?php echo $_SERVER["REDIRECT_eppn"]; ?>';
-        	loginFunctions.doAuthenticate(eppn, redirecTo);
-	     }
-	});
+$(document).ready(function() {
+	if (referer != "" && referer != "undefined") {
+		start = location.href.indexOf("pid");
+		newlocation = location.href.substr(start);
+		redirecTo = newlocation.substr(newlocation.indexOf("=")+1);
+		eppn = '<?php echo esc_js( $eppn ); ?>';
+		loginFunctions.doAuthenticate(eppn, redirecTo);
+	 }
+});
 </script>
 
 <style type="text/css">
 	div.loading {
-	    display:block;
-            width:100%;
-	    height:100%;	
-	    margin-left:auto;	
-	    margin-right:auto;	
-            vertical-align:middle;	
-	    text-align:center;	
+		display:block;
+		width:100%;
+		height:100%;
+		margin-left:auto;
+		margin-right:auto;
+		vertical-align:middle;
+		text-align:center;
 	}
 	div.inner {
-	    display:block;
-            border:thin solid #659EC7;	
-	    margin-top:20%;	
-	    margin-left:auto;	
-	    margin-right:auto;	
-            width:33%;	
-	    padding:1em;
-            font-family: 'verdana', 'sans serif', 'helvetica';	
-	    font-weight:600;
-            font-size:.75em;
-	    color:#659EC7;
+		display:block;
+		border:thin solid #659EC7;
+		margin-top:20%;
+		margin-left:auto;
+		margin-right:auto;
+		width:33%;
+		padding:1em;
+		font-family: 'verdana', 'sans serif', 'helvetica';
+		font-weight:600;
+		font-size:.75em;
+		color:#659EC7;
 	}
 	img.loading {
-	    display:block;
-	    clear:both;
-            top:1%;
-	    margin-left:auto;
-	    margin-right:auto;
+		display:block;
+		clear:both;
+		top:1%;
+		margin-left:auto;
+		margin-right:auto;
 	}
-    </style>
+	</style>
  
  <br/>
 

--- a/page-forms.php
+++ b/page-forms.php
@@ -15,6 +15,9 @@ $pageRoot = getRoot( $post );
 $section = get_post( $pageRoot );
 $isRoot = $section->ID == $post->ID;
 
+// Read and treat Shibboleth EPPN value for use in page.
+$eppn = shibboleth_eppn();
+
 get_header();
 
 ?>
@@ -72,7 +75,7 @@ document.addEventListener( 'wpcf7mailsent', function( event ) {
 		
 		<?php endwhile; ?>
 <form id="loginForm">
-	<input type="hidden" id="eppn" name="eppn" value="<?php echo htmlspecialchars($_SERVER["REDIRECT_eppn"]); ?>">
+	<input type="hidden" id="eppn" name="eppn" value="<?php echo esc_attr( $eppn ); ?>">
 </form>
 
 <script type="text/javascript">
@@ -82,8 +85,8 @@ $(document).ready(function() {
 	eppn = document.getElementById("eppn").value;
 	if (eppn) {
 
-  		loginFunctions.doAuthenticate(eppn);
-  		var timeout = setTimeout('cookie_functions.setDocumentValues("libForma",",","=")',5000);
+		loginFunctions.doAuthenticate(eppn);
+		var timeout = setTimeout('cookie_functions.setDocumentValues("libForma",",","=")',5000);
 
 	}
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This PR does two things:
- changes four calls to `$_SERVER['SERVER_NAME']` to use the Wordpress `get_site_url()` function instead.
- cleans the `forms` and `authenticate` page templates per the WP coding standards

#### Helpful background context (if appropriate)
This cleans some oft-triggered code problems that have caused some recent PRs to be flagged for problems unrelated to the work at hand. The goal is to allow future PRs to more often get cleanly-scoped reviews from both Travis and CodeClimate.

#### How can a reviewer manually see the effects of these changes?
If the hours system and WP-native forms still work, then nothing broke.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-223

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
