### PR TITLE
Make branding splash collapsible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -163,6 +163,8 @@ rules:
   - 0
   - declaration
   generator-star-spacing: 0
+  globals:
+    Modernizr: false
   guard-for-in: 0
   handle-callback-err: 0
   indent: 0

--- a/js/brand.js
+++ b/js/brand.js
@@ -1,0 +1,26 @@
+$(function(){
+
+	// What variable are we using to store toggle status?
+	var toggle = 'brand_closed';
+
+	// This checks if the user has already closed the branding header.
+	// If localStorage
+	if (Modernizr.localstorage) {
+		// Check for the localStorage alert ID item
+		if (localStorage.getItem(toggle) === 'true') {
+			$('.brand-splash').removeClass('big').addClass('compact');
+		}
+	}
+
+	// On click
+	$('.btn-minimize').click(function(){
+		$('.brand-splash').removeClass('big').addClass('compact');
+		if (Modernizr.localstorage) {
+			// Set the localStorage item, using the post ID
+			localStorage.setItem(toggle, 'true');
+		}
+		// Prevent the default click behavior.
+		return false;
+	});
+
+});

--- a/tasks/options/concat.js
+++ b/tasks/options/concat.js
@@ -23,7 +23,8 @@ module.exports = {
       'js/guides-home.js',
       'js/experts-home.js',
       'js/ga_discovery.js',
-      'js/alerts.js'
+      'js/alerts.js',
+      'js/brand.js'
     ],
     dest: 'js/build/home.js'
   },


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This writes a simple piece of javascript that swaps from `big` to `compact` classes on the front page branding element. It also uses localstorage to record when the element has been collapsed, and uses that to keep the smaller display in the future.

#### Helpful background context (if appropriate)
This uses a similar approach to that found in `js/alerts.js`

#### How can a reviewer manually see the effects of these changes?
Deploy this branch, try closing the branding element in any browser. Note that the branding element closes. Now refresh the page and note whether the branding loads smaller or larger.

If a tester needs to revert the setting, enter this in your browser console:
`localStorage.setItem('brand_closed',null);`

*Please note:* The Travis failures on this PR are unrelated to this change. You're welcome to look them over, but there should only be problems on `page-authenticate.php` and `page-forms.php`, neither of which are changed in this PR. There is a separate cleaning branch going to address those issues.

CodeClimate is more of a mixed bag - it might be triggered by existing changes in the `frances/brand-header` branch (which are also being cleaned elsewhere), but if you see any other violations please ask.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-225

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
