### PR TITLE
Adds screenreader content to alert closing

### DIFF
--- a/js/alerts.js
+++ b/js/alerts.js
@@ -47,7 +47,7 @@ function renderAlert(markup,id) {
 
 function setClosable(alert_ID) {
 	// Add a Close icon/svg/button
-	$('.posts--preview--alerts .post').append('<a href="#0" id="close" class="action-close"><i class="icon-remove-sign" aria-hidden="true"></i></a>');
+	$('.posts--preview--alerts .post').append('<a href="#0" id="close" class="action-close"><span class="sr">Dismiss</span><i class="icon-remove-sign" aria-hidden="true"></i></a>');
 	// On click
 	$('#close').click(function(){
 		// Add the necessary transition hide class


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a screenreader-friendly closing element to the anchor that closes an alert box. This is necessary to prevent WAVE errors on front page alerts.

#### Helpful background context (if appropriate)
Having empty elements in links was flagged by a recent a11y review of our website. Alert boxes only appear infrequently, so this was not flagged specifically - but was found in later testing.

#### How can a reviewer manually see the effects of these changes?
Run the WAVE tool on the dev tool when an alert box is present. Note that an Error is returned. Then deploy this branch and repeat the WAVE tool. An error should no longer be present.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-202

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
