### PR TITLE
Bumps version to 1.7.0

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.6.0-@@branch-@@commit
+Version: 1.7.0-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.6.0-@@branch-@@commit
+Version: 1.7.0-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This bumps the theme version to 1.7.0
Release notes are at https://github.com/MITLibraries/MITlibraries-parent/wiki/Draft-Release-Notes

#### Helpful background context (if appropriate)
Compare to #230 (the last time we updated the theme version)

#### How can a reviewer manually see the effects of these changes?
The theme version is reported within WordPress on the admin screen at /wp-admin/themes.php?theme=libraries

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
