### PR TITLE
fix tabnav bug

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -59,13 +59,16 @@ var Core = {
 		if($('.tabnav').length) {
 			// Store a var
 			var tabnav = $('.tabnav');
+			var tabcontent = $('.tabcontent');
 			// Check if URL has hash
 			if(window.location.hash) {
 			  var hash = window.location.hash;
-			  // Remove all active classes from tabnav
+			  // Remove all active classes from tabnav and tabcontent
 			  $('> li', tabnav).removeClass('active');
-			  // Add active class to tab that contains the hash
+			  $('.tab', tabcontent).removeClass('active');
+			  // Add active class to tab and tabcontent that matches the hash
 			  $('h2 a[href="'+hash+'"]', tabnav).parent().parent().addClass('active');
+			  $('.tab'+hash, tabcontent).addClass('active');
 			  // Get the top offset of the active tab
 			 	var activePos = $('li.active', tabnav).offset().top;
 			 	// ...and scroll down to it


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the tabnav bug that prevented the correct tabcontent from showing when navigating directly via URL (hash). 

#### How can a reviewer manually see the effects of these changes?
Visit this page and see that the student spaces tab is highlighted and the study spaces content is showing: 

https://libraries-test.mit.edu/dewey/#tab2

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-410

#### Screenshots (if appropriate)
<img width="1101" alt="screen shot 2018-08-08 at 11 30 33 am" src="https://user-images.githubusercontent.com/4327102/43847439-99ffadd0-9afe-11e8-9935-03c9c6fe684f.png">

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
