### PR TITLE
Fixes Google Map on locations page

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -163,7 +163,7 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'mapJS', get_template_directory_uri() . '/js/build/map.min.js', array( 'jquery' ), '1.5.5', true );
 
-	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw&callback=initMap', array(), '1.7.0', true );
+	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw', array(), '1.7.0', true );
 
 	wp_register_script( 'infobox', get_template_directory_uri() . '/libs/infobox/infobox.js', array( 'googleMapsAPI' ), '1.1.12', true );
 

--- a/functions.php
+++ b/functions.php
@@ -163,7 +163,7 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'mapJS', get_template_directory_uri() . '/js/build/map.min.js', array( 'jquery' ), '1.5.5', true );
 
-	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?sensor=false', array(), false, true );
+	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw&callback=initMap&sensor=false', array(), false, true );
 
 	wp_register_script( 'infobox', get_template_directory_uri() . '/libs/infobox/infobox.js', array( 'googleMapsAPI' ), '1.1.12', true );
 

--- a/functions.php
+++ b/functions.php
@@ -163,7 +163,7 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'mapJS', get_template_directory_uri() . '/js/build/map.min.js', array( 'jquery' ), '1.5.5', true );
 
-	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw&callback=initMap', array(), false, true );
+	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw&callback=initMap', array(), '1.7.0', true );
 
 	wp_register_script( 'infobox', get_template_directory_uri() . '/libs/infobox/infobox.js', array( 'googleMapsAPI' ), '1.1.12', true );
 

--- a/functions.php
+++ b/functions.php
@@ -163,7 +163,7 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_script( 'mapJS', get_template_directory_uri() . '/js/build/map.min.js', array( 'jquery' ), '1.5.5', true );
 
-	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw&callback=initMap&sensor=false', array(), false, true );
+	wp_register_script( 'googleMapsAPI', '//maps.googleapis.com/maps/api/js?key=AIzaSyDJg6fTKm3Pa_NfKEVAdyeRUbVs7zZm5Nw&callback=initMap', array(), false, true );
 
 	wp_register_script( 'infobox', get_template_directory_uri() . '/libs/infobox/infobox.js', array( 'googleMapsAPI' ), '1.1.12', true );
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds an API key to our call to Google Maps, allowing the map to load correctly.

It also removes an outdated `sensor=false` parameter that had been showing warnings in the console. This also adds a version string to the script registration for ease in cache-busting by WordPress. The version string is the same as the current version of the theme itself.

#### How can a reviewer manually see the effects of these changes?
Note the map of locations in production, specifically the warnings about `NoApiKeyWarning'
The development site has this branch in place instead, and the map there loads correctly without this warning.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-449

#### Screenshots (if appropriate)
Production:
![image](https://user-images.githubusercontent.com/1403248/47435258-3b8add00-d772-11e8-97f7-7458e628da9e.png)

Development (with sparsely populated location data, but a working map):
![image](https://user-images.githubusercontent.com/1403248/47435296-4d6c8000-d772-11e8-9486-0794736db533.png)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
