### PR TITLE
Small spacing fixes

### DIFF
--- a/css/partials/_accordion.scss
+++ b/css/partials/_accordion.scss
@@ -50,6 +50,7 @@
 
 .expandable .content {
 	padding: 1em 4em 2em;
+	margin-top: 0;
 	display: none;
 }
 

--- a/css/partials/_locations.scss
+++ b/css/partials/_locations.scss
@@ -54,6 +54,9 @@
 				list-style: circle;
 			}
 	}
+	.content ul+h3 {
+		margin-top: 15px;
+	}
 }
 				
 .locationPage {


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
Adds spacing to headers on the study spaces tab of a location page (https://libraries.mit.edu/hayden/ - click to study spaces tab) and removes spacing from accordion content like on the media room page (https://libraries.mit.edu/barker/media-room/).

#### How can a reviewer manually see the effects of these changes?
View on test: 
https://libraries-test.mit.edu/hayden/
https://libraries-test.mit.edu/barker/media-room/

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-475 
- https://mitlibraries.atlassian.net/browse/NTI-476

#### Screenshots (if appropriate)
Before: 
![screen shot 2019-01-10 at 11 50 26 am](https://user-images.githubusercontent.com/4327102/50983781-39613080-14ce-11e9-82ea-7ec233f4ae99.png)

After: 
![screen shot 2019-01-10 at 11 50 43 am](https://user-images.githubusercontent.com/4327102/50983775-36fed680-14ce-11e9-8115-fb48ff172ecc.png)

Before: 
![screen shot 2019-01-10 at 11 50 09 am](https://user-images.githubusercontent.com/4327102/50983761-2d756e80-14ce-11e9-98fd-35168b8ce4bc.png)

After:
![screen shot 2019-01-10 at 11 49 59 am](https://user-images.githubusercontent.com/4327102/50983752-2a7a7e00-14ce-11e9-82ff-bc1c67ecdb1b.png)

