### PR TITLE
a11y fixes 0319

### DIFF
--- a/css/modules/_colors.scss
+++ b/css/modules/_colors.scss
@@ -43,7 +43,7 @@ $blue-light: hsla(210, 100.0000%, 96.0784%, 1.0000); // #ebf5ff
 
 // Accents
 
-$green-sea: hsla(150, 37.0892%, 41.7647%, 1.0000); // #43926a
+$green-sea: #1c7146; // old #43926a
 $magenta-dark: hsla(323, 51.4563%, 40.3922%, 1.0000); // #9c3273
 $orange-dark: #ca5000;
 

--- a/css/partials/_header.scss
+++ b/css/partials/_header.scss
@@ -53,7 +53,7 @@
 		@include rem-first(padding-bottom, 0.4); // Matches logo padding
 		color: $white;
 		text-transform: uppercase;
-		font-size: 0.5rem;
+		font-size: 0.75rem;
 
 		svg {
 			fill: #c8c8c8;
@@ -123,6 +123,10 @@
 	width:1px; 
 	height:1px; 
 	overflow:hidden;
+	background: #fff;
+	color: blue;
+	display: block;
+	padding: 10px;
 		&:focus {
 			position:static; 
 			width:auto; 

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -262,7 +262,7 @@ body#libraries-homepage {
 			}
 		}
 		.hours {
-			color: #7b7b7b;
+			color: #555;
 			display: inline-block;
 			font-size: 0.875em;
 			font-weight: normal;

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -312,12 +312,12 @@ body#libraries-homepage {
 			}
 		}
 		.location-info {
-			color: #7b7b7b;
+			color: #555;
 			font-size: 0.875em;
 			font-weight: normal;
 		}
 		.map-location {
-			color: #7b7b7b;
+			color: #555;
 			&::before {
 				content: url(#{$imagesPath}/pin-sfw.svg);
 				display: inline-block;
@@ -364,7 +364,7 @@ body#libraries-homepage {
 			}
 		}
 		.phone {
-			color: #7b7b7b;
+			color: #555;
 			&:before {
 				content: url(#{$imagesPath}/phone-mobile-sfw.svg);
 				display: inline-block;

--- a/css/partials/_layout.scss
+++ b/css/partials/_layout.scss
@@ -140,6 +140,8 @@ html.no-js .js-hidden {
 	position: absolute;
 	width: 1px;
 	word-wrap: normal;
+	color: #000;
+	background-color: #fff;
 }
 
 @media screen and (max-width: 720px) {

--- a/css/partials/_menu.scss
+++ b/css/partials/_menu.scss
@@ -53,7 +53,7 @@
       font-size: 0.75em;
 
       a {
-        @include rem-first(padding, 1 0.5 0.5 0.5);
+        padding: 1rem 0.5rem 0.5rem 0.5rem;
         align-items: center;
         flex-direction: column;
         text-transform: uppercase;

--- a/css/partials/_menu.scss
+++ b/css/partials/_menu.scss
@@ -62,7 +62,7 @@
       svg {
         display: block;
         fill: #fff;
-        margin-bottom: .8em;
+        margin-bottom: .4em;
       }
     }
 

--- a/css/partials/_menu.scss
+++ b/css/partials/_menu.scss
@@ -50,10 +50,10 @@
 
     @include bp-tablet--portrait {
       display: block;
-      font-size: 0.5em;
+      font-size: 0.75em;
 
       a {
-        @include rem-first(padding-bottom, 0.5);
+        @include rem-first(padding, 1 0.5 0.5 0.5);
         align-items: center;
         flex-direction: column;
         text-transform: uppercase;
@@ -62,7 +62,7 @@
       svg {
         display: block;
         fill: #fff;
-        margin-bottom: 1em;
+        margin-bottom: .8em;
       }
     }
 
@@ -71,6 +71,7 @@
 
       a {
         text-transform: none;
+        padding-top: 2em;
       }
 
       svg {
@@ -329,7 +330,7 @@
     @include rem-first--4-values(margin, 1, 0, 0.5, 0.5);
     color: $black;
     display: block;
-    font-size: 0.6em;
+    font-size: 0.75em;
     font-weight: bold;
     text-transform: uppercase;
     padding-bottom: 0;

--- a/css/partials/_menu.scss
+++ b/css/partials/_menu.scss
@@ -151,10 +151,11 @@
   .main-nav-header {
     height: 100%;
     font-size: 100%;
-
+    
+    //accessible menu opener buttons
     button {
       border: 0;
-      background: inherit;
+      background: #fff;
       background-image: none;
       font-size: inherit;
       padding: 0;

--- a/css/partials/_typography.scss
+++ b/css/partials/_typography.scss
@@ -51,7 +51,7 @@ a {
 }
 
 .caption {
-	color: hsla(0, 0.0000%, 48.2353%, 1.0000);
+	color: #555;
 	font-size: 0.875em;
 	font-weight: 300;
 	@include bp-tablet--portrait {


### PR DESCRIPTION
#### What does this PR do?
Fixes contrast issues on the homepage, specifically: 
1. All screenreader text (which doesn't visually show at all) was flagged as low contrast because we didn't define styles for those. I have made them all black text on white background but since they aren't seen - this does nothing to the design.
2. The nav items for Ask Us and Account were too small. I adjusted the design so they are larger.
3. The headers inside the nav menus were too small. I adjusted the design so they are larger.
4. The location details were too light gray (times, building, phone) so I made them darker.
5. The green text and buttons at the bottom of the hours was too light for text - I made it darker.
6. The text above "Experts" was too light - I made it darker.

#### Helpful background context (if appropriate)
Came in from Accessibility office.

#### How can a reviewer manually see the effects of these changes?
https://libraries-test.mit.edu/

#### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/NTI-495
