### PR TITLE
Adjust MIT logo in header

### DIFF
--- a/css/partials/_header.scss
+++ b/css/partials/_header.scss
@@ -93,28 +93,30 @@
 
 	.link-logo-mit {
 		display: none;
-		max-width: 59px;
+		align-self: flex-end;
+		order: 4;
+		@include rem-first(margin-bottom, 0.5);
 		margin-left: 0.5em;
+		max-width: 59px;
 		@include rem-first(max-width, 3.6875);
 
 		@include bp-tablet--portrait {
-			align-self: flex-end;
 			display: block;
-			order: 4;
-			@include rem-first(margin-bottom, 0.5);
 		}
 	}
 
 	.logo-mit {
 		display: none;
+		height: auto;
+		@include rem-first(max-height, 2.8125);
+		fill: #b9b7b6;
+
+		.color {
+			fill: #fff;
+		}
+
 		@include bp-tablet--portrait {
 			display: block;
-			height: auto;
-			@include rem-first(max-height, 2.8125);
-			fill: #b9b7b6;
-			.color {
-				fill: #fff;
-			}
 		}
 	}
 }

--- a/css/partials/_header.scss
+++ b/css/partials/_header.scss
@@ -106,17 +106,13 @@
 	}
 
 	.logo-mit {
-		display: none;
+		display: block;
 		height: auto;
 		@include rem-first(max-height, 2.8125);
 		fill: #b9b7b6;
 
 		.color {
 			fill: #fff;
-		}
-
-		@include bp-tablet--portrait {
-			display: block;
 		}
 	}
 }


### PR DESCRIPTION
#### What does this PR do?
This PR adjusts the styles for the MIT logo in the header to only hide/show on mobile, rather than apply different styles. This allows other contexts to unhide rthe logo and have it display correctly in the layout (like in the Child slim header... see https://github.com/MITLibraries/MITLibraries-child/pull/146 )

#### How can a reviewer manually see the effects of these changes?
Branch is deployed to test. 

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-509
