### PR TITLE
Refactor Travis integration for PHP and PHPCS changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,19 @@ matrix:
 
   include:
     # Declare versions of PHP to use. Use one decimal max.
-    - php: '5.3'
-      env: PHPCS_BRANCH=2.9.1 PHPCS_SCRIPT=scripts SNIFF=1
+    # We sniff the current and +1 release of PHP, and just run syntax checking
+    # for others.
+    - php: 'nightly'
+    - php: '7.3'
+    - php: '7.2'
+      env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
     - php: '7.1'
       env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
-    - php: 'nightly'
 
   allow_failures:
     - php: "nightly"
-    - php: "7.1"
+    - php: "7.3"
+    - php: "7.2"
 
 # Use this to prepare the system to install prerequisites or dependencies.
 # e.g. sudo apt-get update.

--- a/codesniffer.mitlib.xml
+++ b/codesniffer.mitlib.xml
@@ -23,11 +23,9 @@
 		<exclude name="WordPress.CodeAnalysis" />
 		<exclude name="WordPress.DB" />
 		<exclude name="WordPress.Files" />
-		<exclude name="WordPress.Functions" />
 		<exclude name="WordPress.NamingConventions" />
 		<exclude name="WordPress.PHP" />
 		<exclude name="WordPress.Utils" />
-		<exclude name="WordPress.Variables" />
 		<exclude name="WordPress.WP" />
 		<exclude name="WordPress.WhiteSpace" />
 	</rule>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This updates our theme integration with Travis, making sure we are evaluating current versions of PHP (version 7.1 and higher), and using the latest releases of PHP CodeSniffer.

#### Helpful background context (if appropriate)
Our recent Travis/PHPCS runs have been erroring, and not returning valid results. Unfortunately this looks very similar in GitHub to just returning flags.

#### How can a reviewer manually see the effects of these changes?
Check Travis to make sure any errors reported are PHPCS flagging security risks, rather than erroring due to invalid sniffs or syntax problems.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-529

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
