### PR TITLE
Adds widget area to 404 template

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,11 +14,21 @@ get_header(); ?>
 				<div class="main-content content-main">
 
 					<article id="post-0" class="post error404 no-results not-found">
-						<header class="entry-header">
-							<h1 class="entry-title">This file was not found.</h1>
-						</header>
 
-						<?php get_template_part( 'inc/site-search' ); ?>
+						<?php if ( is_active_sidebar( 'sidebar-404' ) ) { ?>
+
+							<div id="sidebar-404" class="widget-area" role="complementary">
+								<?php dynamic_sidebar( 'sidebar-404' ); ?>
+							</div>
+
+						<?php } else { ?>
+
+							<header class="entry-header">
+								<h1 class="entry-title">The requested content was not found.</h1>
+							</header>
+							<?php get_template_part( 'inc/site-search' ); ?>
+
+						<?php } ?>
 
 					</article><!-- #post-0 -->
 

--- a/css/style.css
+++ b/css/style.css
@@ -1265,24 +1265,37 @@ a.comment-edit-link:hover {
 /* Search Form / 404 page
 -------------------------------------------------------------- */
 
-.error404 .entry-header {
+article.error404 .entry-header,
+article.error404 h2.widget-title {
 	margin: 3rem 0;
 	border-bottom: 1px solid #ccc;
 	padding-bottom: 2rem;
 }
 
-.error404 .entry-content h2 {
-	font-size: 18px;
+article.error404 h2.widget-title,
+article.error404 h1.entry-title {
+	font-size: 25px;
 	font-weight: normal;
 	margin-top: 1em;
 }
 
-.error404 .entry-content form {
-	margin-bottom: 2r em;
+article.error404 .entry-content form {
+	margin-bottom: 2rem;
 }
 
-.error404 p {
+article.error404 p {
 	margin: 1em 0;
+}
+
+article.error404 ul {
+	margin-bottom: 10px;
+}
+
+article.error404 ul li {
+	list-style: disc;
+	margin-left: 40px;
+	margin-bottom: 5px;
+	line-height: 23px;
 }
 
 /* =Media queries

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.7.0-@@branch-@@commit
+Version: 1.8.0-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/functions.php
+++ b/functions.php
@@ -324,6 +324,17 @@ function mitlib_widgets_init() {
 		'after_title' => '</h3>',
 		'class' => '',
 	) );
+
+	register_sidebar( array(
+		'name'          => __( 'Migrated Content Notice', 'twentytwelve' ),
+		'id'            => 'sidebar-404',
+		'description'   => __( 'Appears on the 404 page, allowing individual sites to post notices about migrated content', 'twentytwelve' ),
+		'before_widget' => '<aside id="%1$s" class="widget %2$s" role="complementary">',
+		'after_widget'  => '</aside>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
 }
 add_action( 'widgets_init', 'mitlib_widgets_init' );
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.7.0-@@branch-@@commit
+Version: 1.8.0-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This creates a new widget area, `Migrated Content Notice`, which is loaded on the 404 template to allow site builders to create custom notices about migrated content.

#### Helpful background context (if appropriate)
This feature is intended to be used as part of a new website for Distinctive Collections, which involves the retirement or migration of almost 2000 pieces of content. Because it will not be possible to create redirects for each piece of retired or migrated content - thus guaranteeing that some traffic will make its way to the theme's 404 template - we are enabling the creation of content advisories at that step in the process.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to the staging server, and a sample advisory created for the `/foo*` path. The content we anticipate being used for the new DC site is at `/test-404`

#### Screenshots:
Current 404 page:
![image](https://user-images.githubusercontent.com/1403248/64282577-c0628d80-cf23-11e9-87cf-3d6b44d757e7.png)

New default 404 page (seen when no widgets are defined - phrasing changes slightly)
![image](https://user-images.githubusercontent.com/1403248/64282628-db350200-cf23-11e9-81c7-1fa70ae9af20.png)

New custom 404 page (content now provided by a widget for a specified URL pattern, replacing the default)
![image](https://user-images.githubusercontent.com/1403248/64282694-fd2e8480-cf23-11e9-8653-b7c90ed9bc28.png)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
