### PR TITLE
Removes links to, and loops of, content indices

### DIFF
--- a/404.php
+++ b/404.php
@@ -18,33 +18,7 @@ get_header(); ?>
 							<h1 class="entry-title">This file was not found.</h1>
 						</header>
 
-						<div class="entry-content">
-							<h2>Search the Libraries' web site:</h2>
-
-							<form action="https://www.google.com/cse" id="cse-search-box">
-								<div>
-									<input type="hidden" name="cx" value="012139403769412284441:qmnizspyywg">
-									<input type="hidden" name="ie" value="UTF-8">
-									<input type="text" name="q" size="80" style="width: 300px;">
-									<input type="submit" name="sa" value="Search">
-								</div>
-							</form>
-
-							<h2>Browse our <a href="/about/site-search">A-Z index of pages</a> on this site.</h2>
-
-							<p>You can also check out these commonly-used resources:</p>
-
-							<ul>
-								<li><a href="//libraries.mit.edu/quicksearch">Quick search: Books, articles, &amp; more at MIT</a></li>
-								<li><a href="//libguides.mit.edu/directory">Staff directory</a></li>
-								<li><a href="/research-guides">Research guides - databases by subject</a></li>
-								<li><a href="/about/shortcuts/">Shortcuts to frequently used pages</a></li>
-								<li><a href="//web.mit.edu/search.html">MIT web site search</a></li>
-							</ul>
-
-							<p><a href="/ask">Need more help? Ask us!</a></p>
-
-						</div><!-- .entry-content -->
+						<?php get_template_part( 'inc/site-search' ); ?>
 
 					</article><!-- #post-0 -->
 

--- a/author.php
+++ b/author.php
@@ -10,75 +10,52 @@
  * @since 1.2.1
  */
 
-get_header(); ?>
+get_header();
 
-	<section id="primary" class="site-content">
-		<div id="content" role="main">
+$sidebar_class = '';
+if ( is_active_sidebar( 'sidebar-1' ) ) {
+	$sidebar_class = 'has-sidebar';
+}
+?>
 
-		<?php if ( have_posts() ) : ?>
+<div id="stage" class="inner" role="main">
+	<div id="content" class="content <?php echo esc_attr( $sidebar_class ); ?>">
 
-			<?php
+		<div class="content-main main-content">
 
-				/*
-				 * Queue the first post, that way we know
-				 * what author we're dealing with (if that is the case).
-				 *
-				 * We reset this later so we can run the loop
-				 * properly with a call to rewind_posts().
-				 */
-				the_post();
-			?>
+			<?php if ( have_posts() ) : ?>
+				<?php
 
-			<header class="archive-header">
-				<h1 class="archive-title">
-					Author Archives:
-					<span class="vcard">
-						<a class="url fn n" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" title="<?php echo esc_attr( get_the_author() ); ?>" rel="me">
+					/*
+					 * Queue the first post, that way we know
+					 * what author we're dealing with (if that is the case).
+					 *
+					 * We reset this later so we can run the loop
+					 * properly with a call to rewind_posts().
+					 */
+					the_post();
+				?>
+				<header class="archive-header">
+					<h1 class="archive-title">
+						Author Archives:
+						<span class="vcard">
 							<?php the_author(); ?>
-						</a>
-					</span>
-				</h1>
-			</header><!-- .archive-header -->
-
-			<?php
-
-				/*
-				 * Since we called the_post() above, we need to
-				 * rewind the loop back to the beginning that way
-				 * we can run the loop properly, in full.
-				 */
-				rewind_posts();
-			?>
-
-			<?php twentytwelve_content_nav( 'nav-above' ); ?>
-
-			<?php
-			// If a user has filled out their description, show a bio on their entries.
-			if ( get_the_author_meta( 'description' ) ) : ?>
-			<div class="author-info">
-				<div class="author-avatar">
-					<?php echo get_avatar( get_the_author_meta( 'user_email' ), apply_filters( 'twentytwelve_author_bio_avatar_size', 60 ) ); ?>
-				</div><!-- .author-avatar -->
-				<div class="author-description">
-					<h2><?php printf( 'About %s', get_the_author() ); ?></h2>
-					<p><?php the_author_meta( 'description' ); ?></p>
-				</div><!-- .author-description	-->
-			</div><!-- .author-info -->
+						</span>
+					</h1>
+				</header><!-- .archive-header -->
 			<?php endif; ?>
 
-			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
-				<?php get_template_part( 'content', get_post_format() ); ?>
-			<?php endwhile; ?>
+			<?php
+			/* We removed the loop because we don't use this display template. */
+			?>
 
-			<?php twentytwelve_content_nav( 'nav-below' ); ?>
+		</div>
 
-		<?php else : ?>
-			<?php get_template_part( 'content', 'none' ); ?>
+		<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
+			<?php get_sidebar(); ?>
 		<?php endif; ?>
 
-		</div><!-- #content -->
-	</section><!-- #primary -->
+	</div>
+</div>
 
-<?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/category.php
+++ b/category.php
@@ -10,45 +10,36 @@
  * @since 1.2.1
  */
 
-get_header(); ?>
+get_header();
+
+$sidebar_class = '';
+if ( is_active_sidebar( 'sidebar-1' ) ) {
+	$sidebar_class = 'has-sidebar';
+}
+?>
 
 <div id="stage" class="inner" role="main">
-	<div id="content" class="content has-sidebar">
+	<div id="content" class="content <?php echo esc_attr( $sidebar_class ); ?>">
 
 		<div class="content-main main-content">
-		<?php if ( have_posts() ) : ?>
-			<header class="archive-header">
-				<h1 class="archive-title">
-					<?php printf( 'Category Archives: %s', '<span>' . single_cat_title( '', false ) . '</span>' ); ?>
-				</h1>
 
-			<?php if ( category_description() ) : // Show an optional category description. ?>
-				<div class="archive-meta"><?php echo category_description(); ?></div>
+			<?php if ( have_posts() ) : ?>
+				<header class="archive-header">
+					<h1 class="archive-title">
+						<?php printf( 'Category Archives: %s', '<span>' . single_cat_title( '', false ) . '</span>' ); ?>
+					</h1>
+				</header><!-- .archive-header -->
 			<?php endif; ?>
-			</header><!-- .archive-header -->
 
 			<?php
-			/* Start the Loop */
-			while ( have_posts() ) : the_post();
-
-				/*
-                 * Include the post format-specific template for the content. If you want to
-                 * this in a child theme then include a file called called content-___.php
-                 * (where ___ is the post format) and that will be used instead.
-				 */
-				get_template_part( 'content', get_post_format() );
-
-			endwhile;
-
-			twentytwelve_content_nav( 'nav-below' );
+			/* We removed the loop because we don't use this display template. */
 			?>
 
-		<?php else : ?>
-			<?php get_template_part( 'content', 'none' ); ?>
-		<?php endif; ?>
-
 		</div>
-<?php get_sidebar(); ?>
+
+		<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
+			<?php get_sidebar(); ?>
+		<?php endif; ?>
 
 	</div><!-- #content -->
 </div>

--- a/functions.php
+++ b/functions.php
@@ -412,54 +412,19 @@ function twentytwelve_comment( $comment, $args, $depth ) {
 endif;
 
 if ( ! function_exists( 'twentytwelve_entry_meta' ) ) :
-/**
- * Prints HTML with meta information for current post: categories, tags, permalink, author, and date.
- *
- * Create your own twentytwelve_entry_meta() to override in a child theme.
- *
- * @since Twenty Twelve 1.0
- */
-function twentytwelve_entry_meta() {
-	// Translators: used between list items, there is a space after the comma.
-	$categories_list = get_the_category_list( __( ', ', 'twentytwelve' ) );
-
-	// Translators: used between list items, there is a space after the comma.
-	$tag_list = get_the_tag_list( '', __( ', ', 'twentytwelve' ) );
-
-	$date = sprintf( '<a href="%1$s" title="%2$s" rel="bookmark"><time class="entry-date" datetime="%3$s">%4$s</time></a>',
-		esc_url( get_permalink() ),
-		esc_attr( get_the_time() ),
-		esc_attr( get_the_date( 'c' ) ),
-		esc_html( get_the_date() )
-	);
-
-	$author = sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>',
-		esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
-		// Translators: View all posts by a given author.
-		esc_attr( sprintf( __( 'View all posts by %s', 'twentytwelve' ), get_the_author() ) ),
-		get_the_author()
-	);
-
-	// Translators: 1 is category, 2 is tag, 3 is the date and 4 is the author's name.
-	if ( $tag_list ) {
-		// Translators: Category, tag, date, and author values.
-		$utility_text = __( 'This entry was posted in %1$s and tagged %2$s on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
-	} elseif ( $categories_list ) {
-		// Translators: Category, date, and author values.
-		$utility_text = __( 'This entry was posted in %1$s on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
-	} else {
-		// Translators: Date and author values.
-		$utility_text = __( 'This entry was posted on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
+	/**
+	 * Normally this function prints HTML with meta information for current
+	 * post: categories, tags, permalink, author, and date. HOWEVER, our theme
+	 * makes no use of this feature by design, and in its unaltered form there
+	 * is a downside to having this code in place.
+	 *
+	 * We've thus removed the function almost entirely.
+	 *
+	 * @since Twenty Twelve 1.0
+	 */
+	function twentytwelve_entry_meta() {
+		return false;
 	}
-
-	printf(
-		$utility_text,
-		$categories_list,
-		$tag_list,
-		$date,
-		$author
-	);
-}
 endif;
 
 if ( ! function_exists( 'is_child_page' ) ) {

--- a/inc/site-search.php
+++ b/inc/site-search.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This is the template for the site search form that points to the Google
+ * Custom Search Engine.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.8.0
+ */
+
+?>
+<div class="entry-content">
+
+	<form action="https://www.google.com/cse" id="cse-search-box">
+		<h2><label for="q">Search the Libraries' web site:</label></h2>
+		<div>
+			<input type="hidden" name="cx" value="012139403769412284441:qmnizspyywg">
+			<input type="hidden" name="ie" value="UTF-8">
+			<input type="text" id="q" name="q" size="80" style="width: 300px;">
+			<input type="submit" name="sa" value="Search">
+		</div>
+	</form>
+
+	<h2>Browse our <a href="/about/site-search">A-Z index of pages</a> on this site.</h2>
+
+	<p>You can also check out these commonly-used resources:</p>
+
+	<ul>
+		<li><a href="//libraries.mit.edu/quicksearch">Quick search: Books, articles, &amp; more at MIT</a></li>
+		<li><a href="//libguides.mit.edu/directory">Staff directory</a></li>
+		<li><a href="/research-guides">Research guides - databases by subject</a></li>
+		<li><a href="/about/shortcuts/">Shortcuts to frequently used pages</a></li>
+		<li><a href="//web.mit.edu/search.html">MIT web site search</a></li>
+	</ul>
+
+	<p><a href="/ask">Need more help? Ask us!</a></p>
+
+</div><!-- .entry-content -->

--- a/search.php
+++ b/search.php
@@ -6,43 +6,26 @@
  * @since 1.2.1
  */
 
-get_header(); ?>
+get_header();
 
-	<section id="primary" class="site-content">
-		<div id="content" role="main">
+$sidebar_class = '';
+if ( is_active_sidebar( 'sidebar-1' ) ) {
+	$sidebar_class = 'has-sidebar';
+}
+?>
 
-		<?php if ( have_posts() ) : ?>
+<div id="stage" class="inner" role="main">
+	<div id="content" class="content <?php echo esc_attr( $sidebar_class ); ?>">
 
-			<header class="page-header">
-				<h1 class="page-title"><?php printf( 'Search Results for: %s', '<span>' . get_search_query() . '</span>' ); ?></h1>
-			</header>
+		<div class="content-main main-content">
+			<?php get_template_part( 'inc/site-search' ); ?>
+		</div>
 
-			<?php twentytwelve_content_nav( 'nav-above' ); ?>
-
-			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
-				<?php get_template_part( 'content', get_post_format() ); ?>
-			<?php endwhile; ?>
-
-			<?php twentytwelve_content_nav( 'nav-below' ); ?>
-
-		<?php else : ?>
-
-			<article id="post-0" class="post no-results not-found">
-				<header class="entry-header">
-					<h1 class="entry-title">Nothing Found</h1>
-				</header>
-
-				<div class="entry-content">
-					<p>Sorry, but nothing matched your search criteria. Please try again with some different keywords.</p>
-					<?php get_search_form(); ?>
-				</div><!-- .entry-content -->
-			</article><!-- #post-0 -->
-
+		<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
+			<?php get_sidebar(); ?>
 		<?php endif; ?>
 
-		</div><!-- #content -->
-	</section><!-- #primary -->
+	</div>
+</div>
 
-<?php get_sidebar(); ?>
 <?php get_footer(); ?>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This change removes certain theme features that are not useful - and in some cases are problematic - for how we build with WordPress.

**1. Empties category and author indices**
Having category and author indices can be problematic in itself, regardless of whether the meta statement is rendered. This change wipes the loop from these templates, so that if a user stumbles upon one there will no longer be anything useful there.

Compare: https://libraries.mit.edu/category/page-root/page/5 with the same URL on the staging site.

**2. Empties search results**
We use a Google CSE for our site search, rather than WordPress' provided search feature. This change wipes the loop from the search template, replacing it with the default search content that we have on our 404 page.

Compare: https://libraries.mit.edu/search/food with the same URL on the staging site.

**3. Removed meta statement**
![image](https://user-images.githubusercontent.com/1403248/63774534-70dceb80-c8ab-11e9-9d62-f7c11421500f.png)

This piece of content contains links to content indices like category lists, author lists, etc. We don't use those lists, and have used categories specifically to determine rendering choices - making them an avenue for content disclosure. This PR empties the function that populates the meta statement, removing the links.

If the first two changes above are comprehensive enough, this change may not be seen - but I can't promise that there aren't other scenarios around the site where this statement gets output. When it does, this change will prevent easier navigation to pages that are now blank.

#### Helpful background context (if appropriate)
Background can be seen in the linked JIRA ticket below.

#### How can a reviewer manually see the effects of these changes?
Coordinate Matt to make sure that this branch has been deployed to the staging server.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-544

#### Screenshots (if appropriate)
## Author template
![image](https://user-images.githubusercontent.com/1403248/63886248-0eb5e080-c9a8-11e9-8991-166fe2f06570.png)

After
![image](https://user-images.githubusercontent.com/1403248/63886267-1a090c00-c9a8-11e9-978f-e07cb008bd28.png)

## Category template
![image](https://user-images.githubusercontent.com/1403248/63886277-22614700-c9a8-11e9-8564-8adbef37e429.png)

After
![image](https://user-images.githubusercontent.com/1403248/63886289-27be9180-c9a8-11e9-971b-195a447689fe.png)

## Search template
![image](https://user-images.githubusercontent.com/1403248/63886299-2db47280-c9a8-11e9-8c90-ee155de6748a.png)

After
![image](https://user-images.githubusercontent.com/1403248/63886307-32792680-c9a8-11e9-9c7e-c5e668baf181.png)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
