### PR TITLE
Removes nav link to Experiments page, bumps theme version

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.8.1-@@branch-@@commit
+Version: 1.8.2-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/inc/nav-main.php
+++ b/inc/nav-main.php
@@ -150,7 +150,6 @@
 					<li><a href="/about/organization">About our organization</a></li>
 					<li><a href="/contact">Contact us</a></li>
 					<li><a href="/jobs">Jobs</a></li>
-					<li><a href="/about/experiments/">Experiments at the Libraries</a></li>
 					<li><a href="/giving">Giving to the MIT Libraries</a></li>
 					<li><a href="/about" class="bottom">More about us</a></li>
 				</ul>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.8.1-@@branch-@@commit
+Version: 1.8.2-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This removes a link from our main navigation, which is coded into the theme. The page in question is being retired.

#### How can a reviewer manually see the effects of these changes?
The branch has been deployed to the staging site.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-753

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1403248/64817220-5d05da80-d577-11e9-9762-02d31a989732.png)

#### Todo:
- [X] Stakeholder approval (the UX team has requested this change)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
