### PR TITLE
Uxws 803 frontpage

### DIFF
--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -601,6 +601,10 @@ body#libraries-homepage {
 		}
 		.guide-list {
 			margin: 0 1em;
+
+			li {
+				display: inline-block;
+			}
 		}
 		.link-ask {
 			color: $color-guides-experts;

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -575,7 +575,7 @@ body#libraries-homepage {
 			margin-left: -4px; // Fights inline-block space
 		}
 		.expert {
-			width: 50%;
+			width: 49%;
 			&:nth-child(3) {
 				display: none;
 			}
@@ -583,9 +583,9 @@ body#libraries-homepage {
 				display: none;
 			}
 			@include bp-tablet--portrait {
-				width: 25%;
+				width: 24%;
 				&:nth-child(n) {
-					display: block;
+					display: inline-block;
 				}
 			}
 		}
@@ -593,6 +593,13 @@ body#libraries-homepage {
 			justify-content: space-between;
 			min-height: 7.625em;
 			margin: 2em 0;
+			ul {
+				width: 100%;
+				li {
+					display: inline-block;
+					vertical-align: top;
+				}
+			}
 		}
 		.expert-photo {
 			border-radius: 50%;

--- a/guide-list.html
+++ b/guide-list.html
@@ -1,53 +1,53 @@
-<div class="guide-list-1">
-	<a href="http://libguides.mit.edu/biology" class="button-secondary--magenta">Biology</a>
-	<a href="http://libguides.mit.edu/mecheng" class="button-secondary--magenta">Mechanical engineering</a>
-	<a href="/scholarly" class="button-secondary--magenta">Scholarly publishing</a>
-	<a href="http://libguides.mit.edu/country" class="button-secondary--magenta">Country data &amp; analysis</a>
-	<a href="http://libguides.mit.edu/history" class="button-secondary--magenta">History</a>
-	<a href="http://libguides.mit.edu/maps" class="button-secondary--magenta">Maps</a>
-	<a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a>
-</div>
-<div class="guide-list-2">
-	<a href="http://libguides.mit.edu/bioinfo" class="button-secondary--magenta">Bioinformatics</a>
-	<a href="http://libguides.mit.edu/eecs" class="button-secondary--magenta">Electrical engineering</a>
-	<a href="http://libguides.mit.edu/music" class="button-secondary--magenta">Music</a>
-	<a href="http://libguides.mit.edu/econ" class="button-secondary--magenta">Economics</a>
-	<a href="http://libguides.mit.edu/findingimages" class="button-secondary--magenta">Finding images</a>
-	<a href="http://libguides.mit.edu/envi" class="button-secondary--magenta">Environment</a>
-	<a href="http://libguides.mit.edu/chemprices" class="button-secondary--magenta">Chemical prices</a>
-	<a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a>
-</div>
-<div class="guide-list-3">
-	<a href="http://libguides.mit.edu/eecs" class="button-secondary--magenta">Computer science</a>
-	<a href="http://libguides.mit.edu/chemeng" class="button-secondary--magenta">Chemical engineering</a>
-	<a href="http://libguides.mit.edu/finance" class="button-secondary--magenta">Finance &amp; investment</a>
-	<a href="http://libguides.mit.edu/references" class="button-secondary--magenta">Citation software</a>
-	<a href="http://libguides.mit.edu/linguistics" class="button-secondary--magenta">Linguistics</a>
-	<a href="http://libguides.mit.edu/energy" class="button-secondary--magenta">Energy</a>
-	<a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a>
-</div>
-<div class="guide-list-4">
-	<a href="http://libguides.mit.edu/gis" class="button-secondary--magenta">Geographic information systems (GIS)</a>
-	<a href="http://libguides.mit.edu/aero" class="button-secondary--magenta">Aeronautics/astronautics</a>
-	<a href="http://libguides.mit.edu/patents" class="button-secondary--magenta">Patents</a>
-	<a href="http://libguides.mit.edu/physics" class="button-secondary--magenta">Physics</a>
-	<a href="http://libguides.mit.edu/market" class="button-secondary--magenta">Market research</a>
-	<a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a>
-</div>
-<div class="guide-list-5">
-	<a href="http://libguides.mit.edu/math" class="button-secondary--magenta">Mathematics</a>
-	<a href="http://libguides.mit.edu/materials" class="button-secondary--magenta">Materials science & engineering</a>
-	<a href="http://libguides.mit.edu/management" class="button-secondary--magenta">Management</a>
-	<a href="/data-management" class="button-secondary--magenta">Data management</a>
-	<a href="http://libguides.mit.edu/standards" class="button-secondary--magenta">Standards</a>
-	<a href="http://libguides.mit.edu/ebooks" class="button-secondary--magenta">E-books</a>
-	<a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a>
-</div>
-<div class="guide-list-6">
-	<a href="http://libguides.mit.edu/civil" class="button-secondary--magenta">Civil & environmental engineering</a>
-	<a href="http://libguides.mit.edu/chem" class="button-secondary--magenta">Chemistry</a>
-	<a href="http://libguides.mit.edu/architect" class="button-secondary--magenta">Architecture & art</a>
-	<a href="http://libguides.mit.edu/polisci" class="button-secondary--magenta">Political science</a>
-	<a href="http://libguides.mit.edu/psych" class="button-secondary--magenta">Psychology</a>
-	<a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a>
-</div>
+<ul class="guide-list-1">
+	<li><a href="http://libguides.mit.edu/biology" class="button-secondary--magenta">Biology</a></li>
+	<li><a href="http://libguides.mit.edu/mecheng" class="button-secondary--magenta">Mechanical engineering</a></li>
+	<li><a href="/scholarly" class="button-secondary--magenta">Scholarly publishing</a></li>
+	<li><a href="http://libguides.mit.edu/country" class="button-secondary--magenta">Country data &amp; analysis</a></li>
+	<li><a href="http://libguides.mit.edu/history" class="button-secondary--magenta">History</a></li>
+	<li><a href="http://libguides.mit.edu/maps" class="button-secondary--magenta">Maps</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+</ul>
+<ul class="guide-list-2">
+	<li><a href="http://libguides.mit.edu/bioinfo" class="button-secondary--magenta">Bioinformatics</a></li>
+	<li><a href="http://libguides.mit.edu/eecs" class="button-secondary--magenta">Electrical engineering</a></li>
+	<li><a href="http://libguides.mit.edu/music" class="button-secondary--magenta">Music</a></li>
+	<li><a href="http://libguides.mit.edu/econ" class="button-secondary--magenta">Economics</a></li>
+	<li><a href="http://libguides.mit.edu/findingimages" class="button-secondary--magenta">Finding images</a></li>
+	<li><a href="http://libguides.mit.edu/envi" class="button-secondary--magenta">Environment</a></li>
+	<li><a href="http://libguides.mit.edu/chemprices" class="button-secondary--magenta">Chemical prices</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+</ul>
+<ul class="guide-list-3">
+	<li><a href="http://libguides.mit.edu/eecs" class="button-secondary--magenta">Computer science</a></li>
+	<li><a href="http://libguides.mit.edu/chemeng" class="button-secondary--magenta">Chemical engineering</a></li>
+	<li><a href="http://libguides.mit.edu/finance" class="button-secondary--magenta">Finance &amp; investment</a></li>
+	<li><a href="http://libguides.mit.edu/references" class="button-secondary--magenta">Citation software</a></li>
+	<li><a href="http://libguides.mit.edu/linguistics" class="button-secondary--magenta">Linguistics</a></li>
+	<li><a href="http://libguides.mit.edu/energy" class="button-secondary--magenta">Energy</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+</ul>
+<ul class="guide-list-4">
+	<li><a href="http://libguides.mit.edu/gis" class="button-secondary--magenta">Geographic information systems (GIS)</a></li>
+	<li><a href="http://libguides.mit.edu/aero" class="button-secondary--magenta">Aeronautics/astronautics</a></li>
+	<li><a href="http://libguides.mit.edu/patents" class="button-secondary--magenta">Patents</a></li>
+	<li><a href="http://libguides.mit.edu/physics" class="button-secondary--magenta">Physics</a></li>
+	<li><a href="http://libguides.mit.edu/market" class="button-secondary--magenta">Market research</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+</ul>
+<ul class="guide-list-5">
+	<li><a href="http://libguides.mit.edu/math" class="button-secondary--magenta">Mathematics</a></li>
+	<li><a href="http://libguides.mit.edu/materials" class="button-secondary--magenta">Materials science & engineering</a></li>
+	<li><a href="http://libguides.mit.edu/management" class="button-secondary--magenta">Management</a></li>
+	<li><a href="/data-management" class="button-secondary--magenta">Data management</a></li>
+	<li><a href="http://libguides.mit.edu/standards" class="button-secondary--magenta">Standards</a></li>
+	<li><a href="http://libguides.mit.edu/ebooks" class="button-secondary--magenta">E-books</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+</ul>
+<ul class="guide-list-6">
+	<li><a href="http://libguides.mit.edu/civil" class="button-secondary--magenta">Civil & environmental engineering</a></li>
+	<li><a href="http://libguides.mit.edu/chem" class="button-secondary--magenta">Chemistry</a></li>
+	<li><a href="http://libguides.mit.edu/architect" class="button-secondary--magenta">Architecture & art</a></li>
+	<li><a href="http://libguides.mit.edu/polisci" class="button-secondary--magenta">Political science</a></li>
+	<li><a href="http://libguides.mit.edu/psych" class="button-secondary--magenta">Psychology</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+</ul>

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -77,7 +77,6 @@ endif; ?>
 		<div class="col-2 flex-item">
 			<div id="home-posts-news" class="posts--preview news-events">
 				<h2><a href="/news">News &amp; events</a></h2>
-				<h3 class="hidden-text" style="margin-top: -1.5em; padding: 0;">News &amp; events</h3><!-- per accesibility review for screen readers -->
 				<div class="flex-container">
 
 		<?php

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -24,19 +24,19 @@ endif; ?>
 			<div class="hours-locations">
 				<h2><a href="/hours">Hours &amp; locations</a></h2>
 				<div class="location">
-					<a href="/barker" aria-hidden="true" class="img-loc barker"><span class="sr">Barker Library</span></a>
+					<a href="/barker" aria-labelledby="barker" class="img-loc barker"><span class="sr" id="barker">Barker Library</span></a>
 					<div class="wrap-loc-info">
 						<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today,</div> <a href="/study/24x7/" class="special">24/7 Study</a><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a></div>
 					</div>
 				</div>
 				<div class="location">
-					<a href="/dewey" aria-hidden="true" class="img-loc dewey"><span class="sr">Dewey Library</span></a>
+					<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
 					<div class="wrap-loc-info">
 						<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today,</div> <a href="/study/24x7/" class="special">24/7 Study</a><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a></div>
 					</div>
 				</div>
 				<div class="location">
-					<a href="/hayden" aria-hidden="true" class="img-loc hayden"><span class="sr">Hayden Library</span></a>
+					<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
 					<div class="wrap-loc-info">
 						<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today,</div> <a href="/study/24x7/" class="special">24/7 Study</a><div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
 					</div>
@@ -49,19 +49,19 @@ endif; ?>
 					<svg class="icon-arrow-down" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="16.3" height="9.4" viewBox="2.7 8.3 16.3 9.4" enable-background="new 2.7 8.3 16.3 9.4" xml:space="preserve"><path d="M18.982 9.538l-8.159 8.159L2.665 9.538l1.284-1.283 6.875 6.875 6.875-6.875L18.982 9.538z"/></svg>Show 3 More
 				</a>
 				<div class="location hidden-mobile inactive-mobile">
-					<a href="/rotch" aria-hidden="true"  class="img-loc rotch"><span class="sr">Rotch Library</span></a>
+					<a href="/rotch" aria-labelledby="rotch" class="img-loc rotch"><span class="sr" id="rotch">Rotch Library</span></a>
 					<div class="wrap-loc-info">
 						<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a></div>
 					</div>
 				</div>
 				<div class="location hidden-mobile inactive-mobile">
-					<a href="/distinctive-collections" aria-hidden="true"  class="img-loc archives"><span class="sr">Distinctive Collections Reading Room</span></a>
+					<a href="/distinctive-collections" aria-labelledby="dc" class="img-loc archives"><span class="sr" id="dc">Distinctive Collections Reading Room</span></a>
 					<div class="wrap-loc-info">
 						<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a></div>
 					</div>
 				</div>
 				<div class="location hidden-mobile inactive-mobile">
-					<a href="/music" aria-hidden="true"  class="img-loc lewis"><span class="sr">Lewis Music Library</span></a>
+					<a href="/music" aria-labelledby="lewis" class="img-loc lewis"><span class="sr" id="lewis">Lewis Music Library</span></a>
 					<div class="wrap-loc-info">
 						<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a></div>
 					</div>

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -96,14 +96,12 @@ endif; ?>
 				</div>
 				<div class="experts-group flex-container">
 					<h3 class="hidden-text" style="margin-top: -1.5em; padding: 0;">Research experts</h3><!-- per accesibility review for screen readers -->
-					<div class="expert">
-					</div>
-					<div class="expert">
-					</div>
-					<div class="expert">
-					</div>
-					<div class="expert">
-					</div>
+					<ul>
+						<li class="expert"></li>
+						<li class="expert"></li>
+						<li class="expert"></li>
+						<li class="expert"></li>
+					</ul>
 				</div>
 				<a href="/experts" class="button-primary--magenta view-experts">All <span class="count">32</span> experts</a>
 			</div><!-- end div.guides-experts -->


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This makes some requested accessibility changes to the front page template:
- Removes an (apparently unneeded) duplicate header tag for News and Events
- Converts the set of research guides to an unordered list
- Converts the set of experts to an unordered list
- Adds accessible names to the location thumbnails

#### Helpful background context (if appropriate)
We got an email from Disability and Access Services recently, asking for these changes.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to the staging site.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-803

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
