### PR TITLE
Sets form legend width to auto

### DIFF
--- a/css/partials/pages/_forms.scss
+++ b/css/partials/pages/_forms.scss
@@ -34,6 +34,7 @@
     font-size: .9rem;
     color: #595959;
     text-transform: uppercase;
+    width: auto;
   }
 
   .button-primary.green,


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This explicitly sets the form legend's width to `auto`, rather than the Boostrap-inherited `100%`.

#### How can a reviewer manually see the effects of these changes?
Check the Staging site...

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-559

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1403248/66428521-2d19ed80-e9e4-11e9-9772-43b35d60e401.png)

#### Todo:
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
