### PR TITLE
Add focus pseudoclass to hover definition on buttons

### DIFF
--- a/css/modules/_buttons.scss
+++ b/css/modules/_buttons.scss
@@ -1,20 +1,23 @@
 @mixin color-button-primary($color) {
 	background: $color;
-	&:hover {
+	&:hover,
+	&:focus {
 		background: darken($color, 15%);
 	}
 }
 
 @mixin color-button-primary--border($color) { // Matches button-primary size when inline with button secondary
 	border: 2px solid $color;
-	&:hover {
+	&:hover,
+	&:focus {
 		border-color: darken($color, 15%);
 	}
 }
 
 @mixin color-button-secondary($color) {
 	color: $color;
-	&:hover {
+	&:hover,
+	&:focus {
 		background: $color;
 		border-color: $color;
 	}
@@ -27,7 +30,8 @@
 	@include bp-tablet--portrait {
 		padding: 0.5em 1em;
 	}
-	&:hover {
+	&:hover,
+	&:focus {
 		text-decoration: none;
 	}
 }
@@ -47,7 +51,8 @@
 		width: auto;
 		@include rem-first(max-width, 12);
 	}
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $color-text--light;
 	}
 	&.inline { // Display primary buttons inline with secondary buttons
@@ -86,7 +91,8 @@
 	transition: background $timer-primary ease,
 							border-color $timer-primary ease,
 							color $timer-primary ease;
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $color-text--light;
 	}
 	@include bp-tablet--portrait {
@@ -99,7 +105,8 @@
 		background: #fff;
 		padding: 0.75em;
 	}
-	&:hover {
+	&:hover,
+	&:focus {
 		text-decoration: none;
 	}
 }

--- a/css/partials/_buttons.scss
+++ b/css/partials/_buttons.scss
@@ -3,7 +3,8 @@
 [class*="button-primary"], 
 .wrap-page [class*="button-primary"] {
 	@extend %button-primary;
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $color-text--light;
 	}
 }
@@ -11,7 +12,8 @@
 [class*="button-secondary"], 
 .wrap-page [class*="button-secondary"] {
 	@extend %button-secondary;
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $color-text--light;
 	}
 }


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This extends the existing styles for buttons to include both the `:focus` as well as `:hover` pseudo-classes.

#### Helpful background context (if appropriate)
This is one of the changes to come from an a11y review conducted by an outside party.

#### How can a reviewer manually see the effects of these changes?
The branch has been deployed to staging.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-566

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
