### PR TITLE
Enables SCSS Lint plugin on CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -53,6 +53,8 @@ engines:
         enabled: false
       Controversial/CamelCaseVariableName:
         enabled: false
+  scss-lint:
+    enabled: true
 ratings:
   paths:
   - "**.css"


### PR DESCRIPTION
## This PR is not meant to be merged! ##

#### What does this PR do?
This is meant to enable the SCSS Lint plugin for use within CodeClimate. Unfortunately, doing this is likely to open a few thousand new flags in our CodeClimate review - because parts of our SCSS are really in need of cleanup.

As a result, this PR is meant to be an optional branch only, to be rebased onto work as desired to get a glimpse, but not part of our regular workflow. Hopefully at some point we can integrate this into our standard workflow, but that may be a bridge too far at the moment.

#### How can a reviewer manually see the effects of these changes?
Look at the CodeClimate report for this PR to get a sense for how healthy the current SCSS stylesheets are.

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
