### PR TITLE
Updates theme content to support Hayden closure

### DIFF
--- a/content-location.php
+++ b/content-location.php
@@ -146,7 +146,7 @@
 
 			<?php if ( is_page( 'hayden' ) ) : ?>
 				<div class="location-extra-content-top" style="padding: 1em 0;margin: 0;color: #008700;font-weight: 600;">
-					<p style="margin-bottom: 0 !important;">We're renovating Hayden in 2020. <a href="/future-spaces/" style="color: #008700;">Get the details »</a>
+					<p style="margin-bottom: 0 !important;">Hayden closed for renovation until Fall 2020. <a href="/future-spaces/" style="color: #008700;">Get the details »</a>
 					</p>
 				</div>
 			<?php endif; ?>

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -38,11 +38,11 @@ endif; ?>
 				<div class="location">
 					<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
 					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today,</div> <a href="/study/24x7/" class="special">24/7 Study</a><div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
+						<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours">Closed for renovation</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
 					</div>
 				</div>
 				<div class="location-hayden-reno">
-					<p><a href="/future-spaces/">Upcoming Hayden renovation details</a>
+					<p><a href="/future-spaces/">Hayden renovation details</a>
 					</p>
 				</div>
 				<a href="#0" class="show-more hidden-non-mobile">

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -154,6 +154,9 @@ get_header(); ?>
 								<?php echo $phone ?>
 								<br/>
 								<?php endif; ?><a class="map" data-target="<?php echo $locationId; ?>" href="#!<?php echo $slug; ?>">Map: <?php echo $building ?></a>
+								<?php if ( 'hayden-library' === $slug ) : ?>
+									<br/><span style="margin-bottom: 0 !important; font-weight: 600;"><a href="/future-spaces/" style="color: #008700;">Hayden closed for renovation until Fall 2020 »</a></span>
+								<?php endif; ?>
 								<?php if ( $study24 == 1 ) : ?>
 									<br/>
 									<a class="space247" href="<?php echo $gStudy24Url; ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>

--- a/page-study-spaces.php
+++ b/page-study-spaces.php
@@ -111,38 +111,42 @@ get_header(); ?>
 										<?php endif; ?>
 									</div>
 									<div class="study-space--info">
-										<div class="ss-1 ss-item">
-										
-											<h4><?php echo $subject ?></h4>
-											<div class="sub">
-												<?php if ( $phone != '' ) : ?>
-												<?php echo $phone ?><br/>
-												<?php endif; ?>
-												Show on map: <br><a href="/locations/#!<?php echo $slug; ?>"><?php echo $building ?></a><br/>
-												<?php if ( get_the_title() !== 'Information Intersection at Stata Center' ) : ?>
-													<span class="hours">Open today<br/>
-													<span data-location-hours="<?php the_title(); ?>"></span></span>
-												<?php
-													endif;
-													if ( $reserveUrl != '' ) :
-												?>
-												<a class="mobileReserve visible-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
-												<?php endif; ?>
+										<?php if ( 'hayden-library' === $slug ) : ?>
+											<div class="ss-item" style="border-right: none;">Great new study spaces coming to Hayden - see: <a href="/future-spaces/">Hayden Renovation</a></div>
+										<?php else : ?>
+											<div class="ss-1 ss-item">
+											
+												<h4><?php echo $subject ?></h4>
+												<div class="sub">
+													<?php if ( $phone != '' ) : ?>
+													<?php echo $phone ?><br/>
+													<?php endif; ?>
+													Show on map: <br><a href="/locations/#!<?php echo $slug; ?>"><?php echo $building ?></a><br/>
+													<?php if ( get_the_title() !== 'Information Intersection at Stata Center' ) : ?>
+														<span class="hours">Open today<br/>
+														<span data-location-hours="<?php the_title(); ?>"></span></span>
+													<?php
+														endif;
+														if ( $reserveUrl != '' ) :
+													?>
+													<a class="mobileReserve visible-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
+													<?php endif; ?>
+												</div>
 											</div>
-										</div>
 
-										<?php if ( $individual != '' ) : ?>
-										<div class="ss-2 ss-item">
-											<h4>Total seats</h4>
-											<?php echo $individual; ?>
-										</div>
-										<?php endif; ?>
-										
-										<?php if ( $spaces != '' ) : ?>
-										<div class="ss-3 ss-item last">
-											<h4>Group spaces</h4>
-											<?php echo $spaces; ?>
-										</div>
+											<?php if ( $individual != '' ) : ?>
+											<div class="ss-2 ss-item">
+												<h4>Total seats</h4>
+												<?php echo $individual; ?>
+											</div>
+											<?php endif; ?>
+											
+											<?php if ( $spaces != '' ) : ?>
+											<div class="ss-3 ss-item last">
+												<h4>Group spaces</h4>
+												<?php echo $spaces; ?>
+											</div>
+											<?php endif; ?>
 										<?php endif; ?>
 									</div>
 								</div>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This makes changes to four page templates to support the coming Hayden closure (which starts officially on Friday):
1. The home page template has its hours integration broken in favor of hard-coded content that is beyond the formatting supported by the hours system.
2. The location template has an updated hard-coded message that links to the project website.
3. The map page needs to support a short message in the Main Locations loop about the project.
4. The study spaces template needs to have a construction-specific message rather than a variety of fields that normal spaces would have populated.

#### Helpful background context (if appropriate)
In an ideal world this type of notice would be something that the content owners can make without developer support - but this is the world we're in. I've spent less than an hour on this, so it probably isn't that big a deal...

#### How can a reviewer manually see the effects of these changes?
This has been deployed to staging. See Matt for the specific URLs.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-578

#### Screenshots (if appropriate)
Front page:
![image](https://user-images.githubusercontent.com/1403248/70942763-62167200-201d-11ea-8199-976ea9d3205f.png)

Location page:
![image](https://user-images.githubusercontent.com/1403248/70942785-6fcbf780-201d-11ea-9a7b-aeec5cf83b87.png)

Map page:
![image](https://user-images.githubusercontent.com/1403248/70942814-7eb2aa00-201d-11ea-8201-10b11079b951.png)

Study spaces:
![image](https://user-images.githubusercontent.com/1403248/70942843-8d995c80-201d-11ea-8480-1192d737c3aa.png)

#### Todo:
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
