### PR TITLE
Creates homepage hours sidebar, with default content fallback

### DIFF
--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -72,11 +72,6 @@ body.page-home {
 				@include svg-max-height-width;
 			}
 		}
-		aside {
-			.textwidget {
-				padding: 1.0625em;
-			}
-		}
 		.active {
 			display: block;
 			opacity: 1;
@@ -253,6 +248,54 @@ body.page-home {
 		}
 		.wrap-loc-info {
 			-ms-flex: 0 1 auto; // Corrects IE10 bug
+		}
+		//
+		// Widget styles in hours sidebar
+		//
+		aside {
+			.widget-title {
+				color: $green-sea;
+			}
+			.textwidget {
+				padding: 1.0625em;
+				font-size: 0.875em;
+				font-weight: 300;
+				a {
+					text-decoration: underline;
+					&:hover,
+					&:focus {
+						text-decoration: none;
+						color: $blue;
+					}
+				}
+				li {
+					list-style: disc;
+				}
+				ul {
+					margin: 0 0 0.625em 1.0625em;
+				}
+			}
+
+			&.callout {
+				background: $green-sea;
+				border-radius: 3px;
+				color: white;
+				margin: 8px;
+				.widget-title {
+					color: white;
+					border-bottom: 1px solid white;
+					padding: 9px 9px 0 9px;
+				}
+				.textwidget {
+					padding: 9px;
+					p {
+						color: white;
+					}
+					a {
+						color: white;
+					}
+				}
+			}
 		}
 	}
 	.img-loc {

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -266,7 +266,6 @@ body.page-home {
 					&:focus {
 						text-decoration: none;
 						color: $blue;
-						font-weight: bold;
 					}
 				}
 				h3 {
@@ -300,6 +299,10 @@ body.page-home {
 					}
 					a {
 						color: white;
+						&:hover,
+						&:focus {
+							font-weight: bold;
+						}
 					}
 				}
 			}

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -276,7 +276,7 @@ body.page-home {
 					list-style: disc;
 				}
 				p {
-					font-size: 1.0625em;
+					font-size: 17px;
 				}
 				ul {
 					margin: 0 0 0.625em 1.0625em;

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -72,6 +72,11 @@ body.page-home {
 				@include svg-max-height-width;
 			}
 		}
+		aside {
+			.textwidget {
+				padding: 1.0625em;
+			}
+		}
 		.active {
 			display: block;
 			opacity: 1;

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -271,6 +271,11 @@ body.page-home {
 				h3 {
 					margin-bottom: 10px;
 				}
+				h4 {
+					color: #404040;
+					font-weight: 600;
+					margin-top: 20px;
+				}
 				li {
 					list-style: disc;
 				}

--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -258,7 +258,7 @@ body.page-home {
 			}
 			.textwidget {
 				padding: 1.0625em;
-				font-size: 0.875em;
+				font-size: 1.0625em;
 				font-weight: 300;
 				a {
 					text-decoration: underline;
@@ -266,10 +266,17 @@ body.page-home {
 					&:focus {
 						text-decoration: none;
 						color: $blue;
+						font-weight: bold;
 					}
+				}
+				h3 {
+					margin-bottom: 10px;
 				}
 				li {
 					list-style: disc;
+				}
+				p {
+					font-size: 1.0625em;
 				}
 				ul {
 					margin: 0 0 0.625em 1.0625em;

--- a/functions.php
+++ b/functions.php
@@ -326,6 +326,16 @@ function mitlib_widgets_init() {
 	) );
 
 	register_sidebar( array(
+		'name'          => __( 'Front Page Hours Area', 'twentytwelve' ),
+		'id'            => 'sidebar-hours',
+		'description'   => __( 'Appears on the front page template to display hours information', 'twentytwelve' ),
+		'before_widget' => '<aside id="%1$s" class="widget %2$s" role="complementary">',
+		'after_widget'  => '</aside>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
+	register_sidebar( array(
 		'name'          => __( 'Migrated Content Notice', 'twentytwelve' ),
 		'id'            => 'sidebar-404',
 		'description'   => __( 'Appears on the 404 page, allowing individual sites to post notices about migrated content', 'twentytwelve' ),

--- a/inc/homepage-hours.php
+++ b/inc/homepage-hours.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Template partial for the homepage hours & locations panel
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.9.1
+ */
+
+?>
+<h2><a href="/hours">Hours &amp; locations</a></h2>
+<div class="location">
+	<a href="/barker" aria-labelledby="barker" class="img-loc barker"><span class="sr" id="barker">Barker Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a></div>
+	</div>
+</div>
+<div class="location">
+	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a></div>
+	</div>
+</div>
+<div class="location">
+	<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours">Closed for renovation</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
+	</div>
+</div>
+<div class="location-hayden-reno">
+	<p><a href="/future-spaces/">Hayden renovation details</a>
+	</p>
+</div>
+<a href="#0" class="show-more hidden-non-mobile">
+	<svg class="icon-arrow-down" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="16.3" height="9.4" viewBox="2.7 8.3 16.3 9.4" enable-background="new 2.7 8.3 16.3 9.4" xml:space="preserve"><path d="M18.982 9.538l-8.159 8.159L2.665 9.538l1.284-1.283 6.875 6.875 6.875-6.875L18.982 9.538z"/></svg>Show 3 More
+</a>
+<div class="location hidden-mobile inactive-mobile">
+	<a href="/rotch" aria-labelledby="rotch" class="img-loc rotch"><span class="sr" id="rotch">Rotch Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a></div>
+	</div>
+</div>
+<div class="location hidden-mobile inactive-mobile">
+	<a href="/distinctive-collections" aria-labelledby="dc" class="img-loc archives"><span class="sr" id="dc">Distinctive Collections Reading Room</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a></div>
+	</div>
+</div>
+<div class="location hidden-mobile inactive-mobile">
+	<a href="/music" aria-labelledby="lewis" class="img-loc lewis"><span class="sr" id="lewis">Lewis Music Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a></div>
+	</div>
+</div>
+<a href="/hours" class="button-primary--green full add-margin link-hours">All hours &amp; locations</a>
+<div class="extra">
+	<a href="/map" class="button-tertiary link-map more"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve"><path d="M16 2.922v12.695c0 0.211-0.117 0.336-0.273 0.336 -0.055 0-0.117-0.016-0.18-0.039l-4.344-2.109c-0.125-0.055-0.281-0.086-0.438-0.086 -0.172 0-0.336 0.031-0.461 0.094l-4.109 2.086C6.062 15.969 5.883 16 5.711 16c-0.156 0-0.305-0.023-0.422-0.07l-4.828-2.141C0.203 13.68 0 13.359 0 13.078V0.383c0-0.219 0.117-0.344 0.289-0.344 0.055 0 0.109 0.008 0.172 0.031l4.828 2.141c0.117 0.047 0.266 0.078 0.422 0.078 0.172 0 0.352-0.039 0.484-0.102l4.109-2.086C10.43 0.039 10.594 0 10.766 0c0.156 0 0.312 0.031 0.438 0.086l4.344 2.109C15.797 2.312 16 2.641 16 2.922zM5.5 14.805V3.484L1 1.523v11.32L5.5 14.805zM10.5 12.508V1.242L6 3.492v11.266L10.5 12.508zM15 3.133l-4-1.906v11.289l4 1.898V3.133z"/></svg> View map</a>
+	<a href="/study" class="button-tertiary link-study more"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="14" height="16" viewBox="0 0 14 16" enable-background="new 0 0 14.001 16" xml:space="preserve"><path d="M13.8 10.2C14.2 10.6 14 11 13.4 11H6c-1.1 0-2-0.9-2-2H1v6.5C1 15.8 0.8 16 0.5 16S0 15.8 0 15.5v-15C0 0.2 0.2 0 0.5 0S1 0.2 1 0.5V1h5.5c1.1 0 2 0.9 2 2h4.9c0.6 0 0.8 0.4 0.4 0.8l-1.9 2.4c-0.3 0.4-0.3 1.2 0 1.6L13.8 10.2zM7.5 8V3c0-0.6-0.4-1-1-1H1v6H7.5zM12.4 10L11.2 8.4c-0.6-0.8-0.6-2 0-2.8L12.4 4H9.5h-1v5H5c0 0.6 0.4 1 1 1H12.4z"/></svg> Find a study space</a>
+	<p>Quiet, group, and 24/7 study spaces available</p>
+</div><!-- end div.extra -->

--- a/page-home-direct.php
+++ b/page-home-direct.php
@@ -22,56 +22,11 @@ endif; ?>
 	<div class="content-main flex-container libraries-home" role="main">
 		<div class="col-1 flex-item">
 			<div class="hours-locations">
-				<h2><a href="/hours">Hours &amp; locations</a></h2>
-				<div class="location">
-					<a href="/barker" aria-labelledby="barker" class="img-loc barker"><span class="sr" id="barker">Barker Library</span></a>
-					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a></div>
-					</div>
-				</div>
-				<div class="location">
-					<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
-					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a></div>
-					</div>
-				</div>
-				<div class="location">
-					<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
-					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours">Closed for renovation</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
-					</div>
-				</div>
-				<div class="location-hayden-reno">
-					<p><a href="/future-spaces/">Hayden renovation details</a>
-					</p>
-				</div>
-				<a href="#0" class="show-more hidden-non-mobile">
-					<svg class="icon-arrow-down" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="16.3" height="9.4" viewBox="2.7 8.3 16.3 9.4" enable-background="new 2.7 8.3 16.3 9.4" xml:space="preserve"><path d="M18.982 9.538l-8.159 8.159L2.665 9.538l1.284-1.283 6.875 6.875 6.875-6.875L18.982 9.538z"/></svg>Show 3 More
-				</a>
-				<div class="location hidden-mobile inactive-mobile">
-					<a href="/rotch" aria-labelledby="rotch" class="img-loc rotch"><span class="sr" id="rotch">Rotch Library</span></a>
-					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a></div>
-					</div>
-				</div>
-				<div class="location hidden-mobile inactive-mobile">
-					<a href="/distinctive-collections" aria-labelledby="dc" class="img-loc archives"><span class="sr" id="dc">Distinctive Collections Reading Room</span></a>
-					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a></div>
-					</div>
-				</div>
-				<div class="location hidden-mobile inactive-mobile">
-					<a href="/music" aria-labelledby="lewis" class="img-loc lewis"><span class="sr" id="lewis">Lewis Music Library</span></a>
-					<div class="wrap-loc-info">
-						<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a></div>
-					</div>
-				</div>
-				<a href="/hours" class="button-primary--green full add-margin link-hours">All hours &amp; locations</a>
-				<div class="extra">
-					<a href="/map" class="button-tertiary link-map more"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve"><path d="M16 2.922v12.695c0 0.211-0.117 0.336-0.273 0.336 -0.055 0-0.117-0.016-0.18-0.039l-4.344-2.109c-0.125-0.055-0.281-0.086-0.438-0.086 -0.172 0-0.336 0.031-0.461 0.094l-4.109 2.086C6.062 15.969 5.883 16 5.711 16c-0.156 0-0.305-0.023-0.422-0.07l-4.828-2.141C0.203 13.68 0 13.359 0 13.078V0.383c0-0.219 0.117-0.344 0.289-0.344 0.055 0 0.109 0.008 0.172 0.031l4.828 2.141c0.117 0.047 0.266 0.078 0.422 0.078 0.172 0 0.352-0.039 0.484-0.102l4.109-2.086C10.43 0.039 10.594 0 10.766 0c0.156 0 0.312 0.031 0.438 0.086l4.344 2.109C15.797 2.312 16 2.641 16 2.922zM5.5 14.805V3.484L1 1.523v11.32L5.5 14.805zM10.5 12.508V1.242L6 3.492v11.266L10.5 12.508zM15 3.133l-4-1.906v11.289l4 1.898V3.133z"/></svg> View map</a>
-					<a href="/study" class="button-tertiary link-study more"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="14" height="16" viewBox="0 0 14 16" enable-background="new 0 0 14.001 16" xml:space="preserve"><path d="M13.8 10.2C14.2 10.6 14 11 13.4 11H6c-1.1 0-2-0.9-2-2H1v6.5C1 15.8 0.8 16 0.5 16S0 15.8 0 15.5v-15C0 0.2 0.2 0 0.5 0S1 0.2 1 0.5V1h5.5c1.1 0 2 0.9 2 2h4.9c0.6 0 0.8 0.4 0.4 0.8l-1.9 2.4c-0.3 0.4-0.3 1.2 0 1.6L13.8 10.2zM7.5 8V3c0-0.6-0.4-1-1-1H1v6H7.5zM12.4 10L11.2 8.4c-0.6-0.8-0.6-2 0-2.8L12.4 4H9.5h-1v5H5c0 0.6 0.4 1 1 1H12.4z"/></svg> Find a study space</a>
-					<p>Quiet, group, and 24/7 study spaces available</p>
-				</div><!-- end div.extra -->
+				<?php if ( is_active_sidebar( 'sidebar-hours' ) ) { ?>
+					<?php dynamic_sidebar( 'sidebar-hours' ); ?>
+				<?php } else { ?>
+					<?php get_template_part( 'inc/homepage-hours' ); ?>
+				<?php } ?>
 			</div><!-- end div.hours-locations -->
 		</div><!-- end div.col-1 -->
 		<div class="col-2 flex-item">


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This defines a new sidebar in the theme, to be displayed on the homepage template only. This sidebar is where library hours and locations information is displayed. If no widgets are defined in the sidebar, it renders the current list of locations.

If any widgets are placed in that sidebar, that content is rendered instead of the default list. The use case for this is the current general closure of the libraries, where it no longer makes sense to list locations individually with each one marked closed.

#### How can a reviewer manually see the effects of these changes?
The branch is currently on staging, with the content that we'll be using it to display.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ENGX-7

#### Screenshots (if appropriate)
Default view:
![image](https://user-images.githubusercontent.com/1403248/77589012-53afe000-6ec1-11ea-8c3a-a58865589f4e.png)

View with widget content:
![image](https://user-images.githubusercontent.com/1403248/77763890-24f54f00-7012-11ea-81ff-69b566c0dad8.png)

#### Todo:
- [X] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
