### PR TITLE
Improves a11y of header logo hover/focus

### DIFF
--- a/css/partials/_header.scss
+++ b/css/partials/_header.scss
@@ -17,9 +17,8 @@
 
 		@include bp-tablet--portrait {
 			@include rem-first(max-width, 6.5);
-			@include rem-first(margin-bottom, 0.5); // Matches nav link padding
 			margin-left: 1.5%;
-			padding: 5px 5px 0 0;
+			padding: 0;
 		}
 
 		a {
@@ -30,6 +29,7 @@
 
 	.logo-mit-lib {
 		fill: $color-text--light;
+		padding: 8px;
 
 		svg {
 			@include rem-first(max-height, 1.75);

--- a/css/partials/_header.scss
+++ b/css/partials/_header.scss
@@ -103,8 +103,10 @@
 		display: none;
 		align-self: flex-end;
 		order: 4;
-		@include rem-first(margin-bottom, 0.5);
-		margin-left: 0.5em;
+		@include rem-first(padding-top, 2);
+		@include rem-first(padding-bottom, 0.5);
+		padding-left: 0.5em;
+		padding-right: 0.5em;
 		max-width: 59px;
 		@include rem-first(max-width, 3.6875);
 

--- a/functions.php
+++ b/functions.php
@@ -110,7 +110,7 @@ function twentytwelve_scripts_styles() {
 
 	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri() );
 
-	wp_register_style( 'libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array( 'twentytwelve-style', 'font-open-sans' ), '1.5.5' );
+	wp_register_style( 'libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array( 'twentytwelve-style', 'font-open-sans' ), '1.9.1' );
 
 	wp_enqueue_style( 'libraries-global' );
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This will improve the highlighting applied to the Libraries and MIT logos in the header, by matching that applied to the rest of the header links.

#### Helpful background context (if appropriate)
This is follow-on work from the a11y review that was conducted last December.

#### How can a reviewer manually see the effects of these changes?
These changes are currently deployed to the staging server.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-573

#### Screenshots (if appropriate)
Before change:
<img width="288" alt="Screen Shot 2020-03-31 at 9 22 40 AM" src="https://user-images.githubusercontent.com/1403248/78141406-724e3380-73f9-11ea-8ea8-ba666d4f9868.png">
<img width="213" alt="Screen Shot 2020-03-31 at 9 22 45 AM" src="https://user-images.githubusercontent.com/1403248/78141409-72e6ca00-73f9-11ea-9548-4a2c922e04b8.png">

After change:
![Screen Shot 2020-03-31 at 12 56 38 PM](https://user-images.githubusercontent.com/1403248/78141367-65314480-73f9-11ea-9f3e-b393102ef764.png)
![Screen Shot 2020-03-31 at 12 56 42 PM](https://user-images.githubusercontent.com/1403248/78141369-65c9db00-73f9-11ea-9063-506938149132.png)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
