### PR TITLE
Adjusts link styles in front page callout widgets

### DIFF
--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -304,9 +304,11 @@ body.page-home {
 					}
 					a {
 						color: white;
+						font-weight: bold;
+						text-decoration: none;
 						&:hover,
 						&:focus {
-							font-weight: bold;
+							text-decoration: underline;
 						}
 					}
 				}


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This tweaks the styling of links in the hours sidebar on the homepage, so that widgets with the `callout` style are displayed differently.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to staging

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ENGX-10

#### Screenshots (if appropriate)
Before:
<img width="381" alt="Screen Shot 2020-04-08 at 11 30 31 AM" src="https://user-images.githubusercontent.com/1403248/78803668-413ba900-798d-11ea-822c-5b92b40961b4.png">

After:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/1403248/78803709-4f89c500-798d-11ea-98ab-27e33a2508ff.png">

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
