### PR TITLE
Improve focus for mobile nav elements

### DIFF
--- a/css/partials/_header.scss
+++ b/css/partials/_header.scss
@@ -62,10 +62,15 @@
 		display: flex;
 		flex-direction: column;
 		order: 1000; // make them last
-		@include rem-first(padding-bottom, 0.4); // Matches logo padding
+		@include rem-first(padding, 0.4); // Matches logo padding
 		color: $white;
 		text-transform: uppercase;
 		font-size: 0.75rem;
+		
+		&:hover,
+		&:focus {
+			background-color: $brand-secondary;
+		}
 
 		svg {
 			fill: #c8c8c8;
@@ -90,13 +95,13 @@
 	}
 
 	.link-account {
-		margin-right: 1em;
-		margin-left: 2em;
+		margin-left: 0.6rem;
+		margin-right: 0.6rem;
+
 	}
 
 	.link-contact {
-		margin-right: 1em;
-		margin-left: 1em;
+		margin-right: auto;
 	}
 
 	.link-logo-mit {

--- a/css/partials/_menu.scss
+++ b/css/partials/_menu.scss
@@ -509,6 +509,12 @@ body.user-is-tabbing *.nav-main {
     display: block;
     margin: 1em auto;
   }
+
+  &:hover,
+  &:focus {
+    background-color: $brand-secondary;
+    background-image: none;
+  }
 }
 
 .no-flexbox {


### PR DESCRIPTION
#### What does this PR do?
Adds a pink highlight to mobile nav elements (hamburger icon, Search, Account, Contact) on hover and when focused in keyboard nav.

#### How can a reviewer manually see the effects of these changes?
1. checkout this branch of the parent theme from your local WP dev environment (see: https://github.com/MITLibraries/wp_mitlibraries_docker)
2. in a test page (http://localhost:8000/?page_id=2), reduce the width of your browser window until you can see the hamburger menu
3. tab through and confirm that the following elements are highlighted in pink when in focus: hamburger menu, Search, Account, Contact
4. confirm that the same pink highlight appears when you mouse over these elements

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-574
- https://mitlibraries.atlassian.net/browse/NTI-577

#### Screenshots (if appropriate)
![Screen Shot 2020-04-15 at 5 03 07 PM](https://user-images.githubusercontent.com/16103405/79388275-0b716400-7f3b-11ea-86b1-209a61d38662.png)

<img width="376" alt="Screen Shot 2020-04-17 at 2 25 45 PM" src="https://user-images.githubusercontent.com/16103405/79601778-5fa15300-80b7-11ea-87e6-c84dc57fd1b3.png">

#### Todo:
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES

#### Requires change to deploy process?
NO
