### PR TITLE
Enable multiple alerts at the same time

### DIFF
--- a/js/alerts.js
+++ b/js/alerts.js
@@ -71,30 +71,33 @@ function showAlerts(json) {
 	// If there is an alert post
 	if (alert_posts_arr.length) {
 
-		// Check for empty title
-		if ('' === alert_posts_arr[0].title.rendered) {
-			alert_posts_arr[0].title.rendered = 'Alert!';
-		}
+		for (i = 0; i < alert_posts_arr.length; i++) {
+			// Check for empty title
+			if ('' === alert_posts_arr[i].title.rendered) {
+				alert_posts_arr[i].title.rendered = 'Alert!';
+			}
 
-		// Alert HTML template
-		alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
-			'<div class="post alert--critical flex-container">' +
-				'<i class="icon-exclamation-sign" aria-hidden="true"></i>' +
-				'<div class="content-post alertText">' +
-					'<h3>' + alert_posts_arr[0].title.rendered + '</h3> ' + alert_posts_arr[0].content.rendered +
+			// Alert HTML template
+			alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
+				'<div class="post alert--critical flex-container">' +
+					'<i class="icon-exclamation-sign" aria-hidden="true"></i>' +
+					'<div class="content-post alertText">' +
+						'<h3>' + alert_posts_arr[i].title.rendered + '</h3> ' + alert_posts_arr[i].content.rendered +
+					'</div>' +
 				'</div>' +
-			'</div>' +
-		'</div>';
+			'</div>';
 
-		// Alert post ID
-		alert_ID = alert_posts_arr[0].id;
+			// Alert post ID
+			alert_ID = alert_posts_arr[i].id;
 
-		renderAlert(alert_template,alert_ID);
+			renderAlert(alert_template,alert_ID);
 
-		// If this is a closable alert
-		if (true === alert_posts_arr[0].meta.closable) {
-			setClosable(alert_ID);
+			// If this is a closable alert
+			if (true === alert_posts_arr[i].meta.closable) {
+				setClosable(alert_ID);
+			}
 		}
+
 	}
 }
 

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -26,7 +26,8 @@ function filterAlerts(posts) {
 
 		// If user has already dismissed this alert, skip it
 		if (Modernizr.localstorage) {
-			if ( true === localStorage.getItem('alert_closed-' + post.id) ) {
+
+			if ( 'true' === localStorage.getItem('alert_closed-' + post.id) ) {
 				console.log('Skipping post ' + post.id + ' because user has closed it');
 				continue;
 			}

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -6,18 +6,35 @@ function filterAlerts(posts) {
 		post_meta,
 		i;
 
+	// Each post
 	for (i = 0; i < posts.length; i++) {
-		// Each post
 		post = posts[i];
-		// Make sure the field exists
-		if ($(post.meta).length) {
-			// Post meta fields
-			post_meta = post.meta;
-			// Make sure the field exists, is an alert, and is confirmed
-			if ($(post_meta.alert).length && true === post_meta.alert && true === post_meta.confirm_alert ) {
-				filtered.push(post);
+
+		console.log(post);
+
+		// If the post has no meta fields, skip it
+		if ( ! $(post.meta).length ) {
+			console.log('Skipping post without meta fields');
+			continue;
+		}
+
+		// If post is not flagged, and confirmed, as an alert, skip it
+		if ( ! ($(post.meta.alert).length && true === post.meta.alert && true === post.meta.confirm_alert ) ) {
+			console.log('Skipping post not flagged and confirmed as an alert');
+			continue;
+		}
+
+		// If user has already dismissed this alert, skip it
+		if (Modernizr.localstorage) {
+			if ( true === localStorage.getItem('alert_closed-' + post.id) ) {
+				console.log('Skipping post ' + post.id + ' because user has closed it');
+				continue;
 			}
 		}
+
+		console.log('Adding post to filtered list');
+		filtered.push(post);
+
 	};
 
 	return filtered;
@@ -37,24 +54,12 @@ function moveCalendar(stepSize) {
 }
 
 function renderAlert(markup,id) {
-	// If localStorage
-	if (Modernizr.localstorage) {
-		// Check for the localStorage alert ID item
-		if (localStorage.getItem('alert_closed-' + id) !== 'true') {
-			// Append the template
-			$(markup).prependTo('.wrap-page');
-			// Remove the necessary transition class with a timeout, so that the animation shows.
-			setTimeout(function() {
-				$('.posts--preview--alerts').removeClass('transition-vertical--hide');
-			}, 300);
-		}
-	} else { // No localStorage
-		// Append the template, etc.
-		$(markup).prependTo('.wrap-page');
-		setTimeout(function() {
-			$('.posts--preview--alerts').removeClass('transition-vertical--hide');
-		}, 300);
-	}
+	// Append the template
+	$(markup).prependTo('.wrap-page');
+	// Remove the necessary transition class with a timeout, so that the animation shows.
+	setTimeout(function() {
+		$('.posts--preview--alerts').removeClass('transition-vertical--hide');
+	}, 300);
 }
 
 function setClosable(alert_ID) {

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -30,7 +30,8 @@ function renderAlert(markup,id) {
 		if (localStorage.getItem('alert_closed-' + id) !== 'true') {
 			// Append the template
 			$(markup).prependTo('.wrap-page');
-			$('.gldp-default').animate({"top":"292px"});
+			// Bump the hours calendar down, if it is present.
+			$('.gldp-default').position({top: $('.gldp-default').position().top + 152});
 			// Remove the necessary transition class with a timeout, so that the animation shows.
 			setTimeout(function() {
 				$('.posts--preview--alerts').removeClass('transition-vertical--hide');
@@ -52,7 +53,8 @@ function setClosable(alert_ID) {
 	$('#close').click(function(){
 		// Add the necessary transition hide class
 		$('.posts--preview--alerts').addClass('transition-vertical--hide');
-		$('.gldp-default').css({"top":"105px"});
+		// Bump the hours calendar down, if it is present.
+		$('.gldp-default').position({top: $('.gldp-default').position().top - 152});
 		// If localStorage
 		if (Modernizr.localstorage) {
 			// Set the localStorage item, using the post ID

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -23,6 +23,19 @@ function filterAlerts(posts) {
 	return filtered;
 }
 
+// This is needed because, for some reason, the hours screen uses a navigation
+// element that is absolutely positioned. Thus, as alerts are added or closed,
+// we need to explicitly reposition that element.
+function moveCalendar(stepSize) {
+	if ( ! $('.gldp-default').position() ) {
+		console.log('Calendar not present');
+		return;
+	}
+	oldTop = $('.gldp-default').position().top;
+	console.log('Calendar exists at ' + oldTop);
+	$('.gldp-default').animate({top: oldTop + stepSize});
+}
+
 function renderAlert(markup,id) {
 	// If localStorage
 	if (Modernizr.localstorage) {
@@ -31,7 +44,7 @@ function renderAlert(markup,id) {
 			// Append the template
 			$(markup).prependTo('.wrap-page');
 			// Bump the hours calendar down, if it is present.
-			$('.gldp-default').position({top: $('.gldp-default').position().top + 152});
+			moveCalendar(152);
 			// Remove the necessary transition class with a timeout, so that the animation shows.
 			setTimeout(function() {
 				$('.posts--preview--alerts').removeClass('transition-vertical--hide');
@@ -52,9 +65,9 @@ function setClosable(alert_ID) {
 	// On click
 	$('#close').click(function(){
 		// Add the necessary transition hide class
-		$('.posts--preview--alerts').addClass('transition-vertical--hide');
+		$(this).closest('.posts--preview--alerts').addClass('transition-vertical--hide');
 		// Bump the hours calendar down, if it is present.
-		$('.gldp-default').position({top: $('.gldp-default').position().top - 152});
+		moveCalendar(-152);
 		// If localStorage
 		if (Modernizr.localstorage) {
 			// Set the localStorage item, using the post ID
@@ -66,6 +79,7 @@ function setClosable(alert_ID) {
 function showAlerts(json) {
 	var alert_posts_arr = [],
 		alert_ID,
+		alert_title,
 		alert_template;
 
 	alert_posts_arr = filterAlerts(json)
@@ -74,23 +88,21 @@ function showAlerts(json) {
 	if (alert_posts_arr.length) {
 
 		for (i = 0; i < alert_posts_arr.length; i++) {
+			// Alert post ID
+			alert_ID = alert_posts_arr[i].id;
+
 			// Check for empty title
-			if ('' === alert_posts_arr[i].title.rendered) {
-				alert_posts_arr[i].title.rendered = 'Alert!';
-			}
+			alert_title = ('' === alert_posts_arr[i].title.rendered) ? 'Alert!' : alert_posts_arr[i].title.rendered;
 
 			// Alert HTML template
 			alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
 				'<div class="post alert--critical flex-container">' +
 					'<i class="icon-exclamation-sign" aria-hidden="true"></i>' +
 					'<div class="content-post alertText">' +
-						'<h3>' + alert_posts_arr[i].title.rendered + '</h3> ' + alert_posts_arr[i].content.rendered +
+						'<h3>' + alert_title + '</h3> ' + alert_posts_arr[i].content.rendered +
 					'</div>' +
 				'</div>' +
 			'</div>';
-
-			// Alert post ID
-			alert_ID = alert_posts_arr[i].id;
 
 			renderAlert(alert_template,alert_ID);
 

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -6,34 +6,28 @@ function filterAlerts(posts) {
 		post_meta,
 		i;
 
-	// Each post
+	// For each post...
 	for (i = 0; i < posts.length; i++) {
 		post = posts[i];
 
-		console.log(post);
-
-		// If the post has no meta fields, skip it
+		// If the post has no meta fields, skip it.
 		if ( ! $(post.meta).length ) {
-			console.log('Skipping post without meta fields');
 			continue;
 		}
 
-		// If post is not flagged, and confirmed, as an alert, skip it
+		// If post is not flagged, and confirmed, as an alert, skip it.
 		if ( ! ($(post.meta.alert).length && true === post.meta.alert && true === post.meta.confirm_alert ) ) {
-			console.log('Skipping post not flagged and confirmed as an alert');
 			continue;
 		}
 
-		// If user has already dismissed this alert, skip it
+		// If user has already dismissed this alert, skip it.
 		if (Modernizr.localstorage) {
-
 			if ( 'true' === localStorage.getItem('alert_closed-' + post.id) ) {
-				console.log('Skipping post ' + post.id + ' because user has closed it');
 				continue;
 			}
 		}
 
-		console.log('Adding post to filtered list');
+		// Still here? Add post to list for processing.
 		filtered.push(post);
 
 	};
@@ -46,11 +40,9 @@ function filterAlerts(posts) {
 // we need to explicitly reposition that element.
 function moveCalendar(stepSize) {
 	if ( ! $('.gldp-default').position() ) {
-		console.log('Calendar not present');
 		return;
 	}
 	oldTop = $('.gldp-default').position().top;
-	console.log('Calendar exists at ' + oldTop);
 	$('.gldp-default').animate({top: oldTop + stepSize});
 }
 
@@ -89,37 +81,38 @@ function showAlerts(json) {
 	alert_posts_arr = filterAlerts(json)
 
 	// If there is an alert post
-	if (alert_posts_arr.length) {
-
-		for (i = 0; i < alert_posts_arr.length; i++) {
-			// Alert post ID
-			alert_ID = alert_posts_arr[i].id;
-
-			// Check for empty title
-			alert_title = ('' === alert_posts_arr[i].title.rendered) ? 'Alert!' : alert_posts_arr[i].title.rendered;
-
-			// Alert HTML template
-			alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
-				'<div class="post alert--critical flex-container">' +
-					'<i class="icon-exclamation-sign" aria-hidden="true"></i>' +
-					'<div class="content-post alertText">' +
-						'<h3>' + alert_title + '</h3> ' + alert_posts_arr[i].content.rendered +
-					'</div>' +
-				'</div>' +
-			'</div>';
-
-			renderAlert(alert_template,alert_ID);
-
-			// If this is a closable alert
-			if (true === alert_posts_arr[i].meta.closable) {
-				setClosable(alert_ID);
-			}
-		}
-
-		// Bump the hours calendar down, if it is present.
-		moveCalendar(alert_posts_arr.length * 152);
-
+	if ( ! alert_posts_arr.length) {
+		return
 	}
+
+	for (i = 0; i < alert_posts_arr.length; i++) {
+		// Alert post ID
+		alert_ID = alert_posts_arr[i].id;
+
+		// Check for empty title
+		alert_title = ('' === alert_posts_arr[i].title.rendered) ? 'Alert!' : alert_posts_arr[i].title.rendered;
+
+		// Alert HTML template
+		alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
+			'<div class="post alert--critical flex-container">' +
+				'<i class="icon-exclamation-sign" aria-hidden="true"></i>' +
+				'<div class="content-post alertText">' +
+					'<h3>' + alert_title + '</h3> ' + alert_posts_arr[i].content.rendered +
+				'</div>' +
+			'</div>' +
+		'</div>';
+
+		renderAlert(alert_template,alert_ID);
+
+		// If this is a closable alert
+		if (true === alert_posts_arr[i].meta.closable) {
+			setClosable(alert_ID);
+		}
+	}
+
+	// Bump the hours calendar down, if it is present.
+	moveCalendar(alert_posts_arr.length * 152);
+
 }
 
 $(function(){

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -43,8 +43,6 @@ function renderAlert(markup,id) {
 		if (localStorage.getItem('alert_closed-' + id) !== 'true') {
 			// Append the template
 			$(markup).prependTo('.wrap-page');
-			// Bump the hours calendar down, if it is present.
-			moveCalendar(152);
 			// Remove the necessary transition class with a timeout, so that the animation shows.
 			setTimeout(function() {
 				$('.posts--preview--alerts').removeClass('transition-vertical--hide');
@@ -111,6 +109,9 @@ function showAlerts(json) {
 				setClosable(alert_ID);
 			}
 		}
+
+		// Bump the hours calendar down, if it is present.
+		moveCalendar(alert_posts_arr.length * 152);
 
 	}
 }


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This enables the theme to display multiple alerts at the same time. It does this by adding a for loop to the showAlerts function in the alerts.js library.

This is a bit unfortunate, as the library already loops over all alert posts as part of a filtering process - so ideally there would be only one iteration. Doing that refactoring, however, may not be worth doing at this point, given that we don't anticipate using multiple alerts very often.

#### Helpful background context (if appropriate)
The use case for this work is the ability to add a banner or message to our staging server warning folks that they're not looking at a production website. With this change, that message moves into the realm of website content, rather than application code or infrastructure configuration.

#### How can a reviewer manually see the effects of these changes?
Adding multiple alerts within WordPress should cause multiple alerts to appear. This is done by creating Post records, and checking the "is Alert" and "confirmed" checkboxes in the admin UI for that post.

The Staging site currently has this branch, where UX has reviewed this work and approved it.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-920

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
