### PR TITLE
Refactor OpenGraph attributes

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,13 +20,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="The libraries of the Massachusetts Institute of Technology - Search, Visit, Research, Explore" />
 <title><?php wp_title( '|', true, 'right' ); ?></title>
-<meta property="og:title" content="MIT Libraries"/>
-<meta property="og:image" content="<?php echo esc_url( get_template_directory_uri() . '/images/mit-libraries-logo-black-yellow-1200-1200.png', 'https' ); ?>"/>
-<meta property="og:image:type" content="image/png" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="1200" />
-<meta property="og:image:alt" content="MIT Libraries logo" />
-<meta property="og:url" content="//libraries.mit.edu">
+<?php get_template_part( 'inc/header', 'opengraph' ); ?>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 <?php wp_head(); ?>

--- a/inc/header-opengraph.php
+++ b/inc/header-opengraph.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The OpenGraph (or other social integration) metadata for a page.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.9.2
+ */
+
+?>
+<?php
+/**
+ * We need to load the global $wp object in order to accurately render the
+ * current URL.
+ */
+global $wp;
+
+/**
+ * We need the global $post object to load page content, because we aren't
+ * in The Loop yet.
+ * Reference: https://codex.wordpress.org/Class_Reference/WP_Post
+ */
+global $post;
+
+?>
+<meta property="og:title" content="<?php wp_title( '|', true, 'right' ); ?>"/>
+<meta property="og:type" content="website" />
+<meta property="og:image" content="<?php echo esc_url( get_template_directory_uri() . '/images/mit-libraries-logo-black-yellow-1200-1200.png', 'https' ); ?>"/>
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="1200" />
+<meta property="og:image:alt" content="MIT Libraries logo" />
+<meta property="og:description" content="<?php echo esc_attr( ( $post->excerpt ) ? $post->excerpt : wp_trim_excerpt( $post->id ) ); ?>" />
+<meta property="og:url" content="<?php echo esc_url( home_url( $wp->request ) . '/' ); ?>">


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This takes our OpenGraph meta tags from `header.php` and creates a new partial, `inc/header-opengraph.php`. This partial makes some changes, and also sets up additional overrides by the News theme without needing to fork the entire header:

- Page titles are now the same as the title element, rather than just "MIT Libraries"
- The page excerpt, or the truncated page content, are used in the description field
- The URL value matches what the browser shows, rather than our homepage
- A required Type field is added ("website" for all content)

The Libraries' network logo is always used as the image.

Please note: this is part of two coordinated PRs. The other is MITLibraries/MITLibraries-news#129. The Child theme is not currently implementing an override to these templates.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to staging. It should result in no visible changes. To see the difference, compare the behavior of Slack or Facebook when sharing URLs from the staging server.

https://developers.facebook.com/tools/debug/ is a useful tool for previewing how Facebook will see these attributes. You can also paste a URL directly into Slack and see how it appears there.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-949

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES - this PR anticipates the successful deploy of the related PR in the News theme.

#### Requires change to deploy process?
NO
