### PR TITLE
Update text of Hayden Library renovation alert

### DIFF
--- a/content-location.php
+++ b/content-location.php
@@ -147,8 +147,8 @@
 			<?php if ( is_page( 'hayden' ) ) : ?>
 				<div class="location-extra-content-top" style="padding: 1em 0;margin: 0;color: #008700;font-weight: 600;">
 					<p style="margin-bottom: 0 !important;">
-						<strong style="font-weight: 900;">Hayden closed for renovation until Fall 2020.</strong><br>
-						For details on collections and services and a preview of the new space, see <a href="/future-spaces/" style="color: #008700;">Hayden Renovation »</a>
+						<strong style="font-weight: 900;">Hayden is closed for renovation.</strong>
+						For details on collections and services and <br>a preview of the new space, see <a href="/future-spaces/" style="color: #008700;">Hayden Renovation »</a>
 					</p>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
## Status
`needs review`

#### What does this PR do?
Updates the spacing and language of the alert on the Hayden Library location page notifying users of the renovation.

#### How can a reviewer manually see the effects of these changes?
On https://libraries-stage.mit.edu/hayden/, the green alert text should look like this: 
```
Hayden is closed for renovation. For details on collections and services and
a preview of the new space, see Hayden Renovation
```

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-977

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES (updates this theme; does not require others)

#### Requires change to deploy process?
NO
