### PR TITLE
Simple implementation of new footer

### DIFF
--- a/css/partials/_footer.scss
+++ b/css/partials/_footer.scss
@@ -172,6 +172,7 @@
 	.about-mit {
 		font-size: 0.625em;
 		margin-bottom: 2em;
+    margin-right: 1em;
 		span {
 			color: #eeeeee;
 			text-transform: uppercase;
@@ -190,7 +191,7 @@
 	.license {
 		color: #fff;
 		font-size: 0.6875em;
-		width: 100%;
+    margin-left: auto;
 		a {
 			color: #ededed;
 			text-decoration: underline;

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.10.0-@@branch-@@commit
+Version: 1.10.1-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/footer.php
+++ b/footer.php
@@ -62,7 +62,7 @@
 			</a><!-- End MIT Libraries Logo -->
 			
 			<div class="social flex-container">
-				<p class="text-find-us">Find us on</p>
+				<p class="text-find-us sr">Find us on</p>
 					<a href="//twitter.com/mitlibraries" title="Twitter">
 						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
 						<span class="sr">Twitter</span>
@@ -100,31 +100,26 @@
 			</div><!-- end div.social -->
 			
 			<div class="links-primary flex-container">
-				<span><a href="/faculty" class="link-sub">Faculty</a></span>
-				<span><a href="/alumni" class="link-sub">Alumni</a></span>
-				<span><a href="/visitors" class="link-sub">Visitors</a></span>
-				<span><a href="/giving" class="link-sub">Giving</a></span>
-				<span><a href="/disabilities" class="link-sub">Persons with disabilities</a></span>
+				<span><a href="/privacy" class="link-sub">Privacy</a></span>
+				<span><a href="/permissions" class="link-sub">Permissions</a></span>
+				<span><a href="https://accessibility.mit.edu/" class="link-sub">Accessibility</a></span>
 			</div><!-- End div.links-primary -->
 			
 		</div><!-- End div.identity -->
 	</div>
 	
 	<div class="footer-info-institute">
-		<a class="link-logo-mit" href="//www.mit.edu">
+		<a class="link-logo-mit" href="https://www.mit.edu">
 			<span class="sr">MIT</span>
 			<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
 		</a><!-- End MIT Logo -->
 		
 		<div class="about-mit">
-			<span>MASSACHUSETTS INSTITUTE OF TECHNOLOGY </span>
-			<span>77 MASSACHUSETTS AVENUE </span>
-			<span>CAMBRIDGE MA 02139-4307</span>
+			<span class="item">Massachusetts Institute of Technology</span>
 		</div><!-- End div.about-mit -->
 		
-		<div class="license">Licensed under the <a href="http://creativecommons.org/licenses/by-nc/2.0/" class="license-cc">Creative Commons Attribution Non-Commercial License</a> unless otherwise noted. <a href="/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
-		</div><!-- End footer.footer-info-institure -->
-	</div>
+		<div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
+	</div><!-- End div.footer-info-institure -->
 </footer>
 	
 

--- a/footer.php
+++ b/footer.php
@@ -63,17 +63,17 @@
 			
 			<div class="social flex-container">
 				<p class="text-find-us sr">Find us on</p>
-					<a href="//twitter.com/mitlibraries" title="Twitter">
+					<a href="https://twitter.com/mitlibraries" title="Twitter">
 						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
 						<span class="sr">Twitter</span>
 					</a><!-- End Twitter -->
 					
-					<a href="/facebook" title="Facebook">
+					<a href="https://www.facebook.com/mitlib" title="Facebook">
 						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
 						<span class="sr">Facebook</span>
 					</a><!-- End Facebook -->
 					
-					<a href="//instagram.com/mitlibraries/" title="Instagram">
+					<a href="https://instagram.com/mitlibraries/" title="Instagram">
 						<svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2
 	c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1
 	c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4
@@ -87,12 +87,12 @@
 
 					</a><!-- End Instagram -->
 					
-					<a href="//www.youtube.com/user/MITLibraries" title="YouTube">
+					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
 						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
 						<span class="sr">YouTube</span>
 					</a><!-- End YouTube -->
 
-					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
+					<a href="https://libguides.mit.edu/mit-feeds" title="RSS">
 						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
 						<span class="sr">RSS</span>
 					</a><!-- End RSS -->
@@ -100,9 +100,9 @@
 			</div><!-- end div.social -->
 			
 			<div class="links-primary flex-container">
-				<span><a href="/privacy" class="link-sub">Privacy</a></span>
-				<span><a href="/permissions" class="link-sub">Permissions</a></span>
-				<span><a href="https://accessibility.mit.edu/" class="link-sub">Accessibility</a></span>
+				<span><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+				<span><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
+				<span><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
 			</div><!-- End div.links-primary -->
 			
 		</div><!-- End div.identity -->

--- a/functions.php
+++ b/functions.php
@@ -96,6 +96,8 @@ add_action( 'after_setup_theme', 'twentytwelve_setup' );
 function twentytwelve_scripts_styles() {
 	global $wp_styles;
 
+	$theme_version = wp_get_theme()->get( 'Version' );
+
 	/*
 	 * Adds JavaScript to pages with the comment form to support
 	 * sites with threaded comments (when in use).
@@ -110,19 +112,19 @@ function twentytwelve_scripts_styles() {
 
 	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri() );
 
-	wp_register_style( 'libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array( 'twentytwelve-style', 'font-open-sans' ), '1.9.1' );
+	wp_register_style( 'libraries-global', get_template_directory_uri() . '/css/build/minified/global.css', array( 'twentytwelve-style', 'font-open-sans' ), $theme_version );
 
 	wp_enqueue_style( 'libraries-global' );
 
-	wp_register_style( 'mitlib-forms', get_template_directory_uri() . '/css/build/minified/forms.min.css', array( 'libraries-global' ), '1.7.0' );
+	wp_register_style( 'mitlib-forms', get_template_directory_uri() . '/css/build/minified/forms.min.css', array( 'libraries-global' ), $theme_version );
 
-	wp_register_style( 'get-it', get_template_directory_uri() . '/css/build/minified/get-it.min.css', array( 'libraries-global' ), '1.5.5' );
+	wp_register_style( 'get-it', get_template_directory_uri() . '/css/build/minified/get-it.min.css', array( 'libraries-global' ), $theme_version );
 
 	wp_register_style( 'hours-mobile', get_template_directory_uri() . '/css/hours-mobile.css', false, null, 'all' );
 
 	wp_register_style( 'hours-gldatepicker', get_template_directory_uri() . '/libs/datepicker/styles/glDatePicker.default.css', false, null, 'all' );
 
-	wp_register_style( 'hours', get_template_directory_uri() . '/css/build/minified/hours.min.css', array( 'libraries-global', 'hours-mobile', 'hours-gldatepicker' ), '1.5.5' );
+	wp_register_style( 'hours', get_template_directory_uri() . '/css/build/minified/hours.min.css', array( 'libraries-global', 'hours-mobile', 'hours-gldatepicker' ), $theme_version );
 
 	wp_register_style( 'bootstrapCSS', get_stylesheet_directory_uri() . '/css/bootstrap.css', 'false', '', false );
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.10.0-@@branch-@@commit
+Version: 1.10.1-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
This PR implements the new footer using a minimal approach, working within the existing markup and styles whereever possible.

It also bumps the theme version, and implements a more robust way of cache-busting when loading styles to follow the theme's own version string.

#### Helpful background context (if appropriate)
This is downstream work from MITLibraries/mitlib-style#94 , but doesn't use a wholesale implementation of the design system's markup and styles.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to staging, or if you have a local docker WP it can be built and used there.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1012

#### Screenshots (if appropriate)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
