### PR TITLE
Replicates some list styling from ul to ol elements

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -89,6 +89,12 @@ img {
 	line-height: 23px;
 }
 
+.entry-content ol li {
+	margin-left: 40px;
+	margin-bottom: 5px;
+	line-height: 23px;
+}
+
 .entry-content ul, #mainContent ul {
 	margin-bottom: 10px;
 }


### PR DESCRIPTION
#### What does this PR do?

This copies a block of styles that was previously defined for unordered lists, and applies them to ordered lists. The rule directly above this change contains four rules for `.entry-content ul li` conditions. Three of them are now applied to `.entry-content ol li` conditions (the fourth assigns a disc bullet style, which is inappropriate for ordered lists)

#### Helpful background context (if appropriate)
Frankly, the way our styles are defined and flow from parent to child themes right now is kind of a mess. Straightening everything out promises to be a bit of a nightmare, so right now we're just tactically fixing this one problem.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to staging (link not included here, ask on Slack)

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1071

#### Screenshots (if appropriate)
Before:
![Screen Shot 2020-11-30 at 4 15 56 PM](https://user-images.githubusercontent.com/1403248/100669082-d92a4080-332a-11eb-8f31-5ee38b36db26.png)

After:
![Screen Shot 2020-11-30 at 4 15 41 PM](https://user-images.githubusercontent.com/1403248/100669096-e0e9e500-332a-11eb-8754-01e215b84b0c.png)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
