### PR TITLE
Revert Hayden closure notices

### DIFF
--- a/content-location.php
+++ b/content-location.php
@@ -144,15 +144,6 @@
 	<div id="content" class="content <?php echo $strLocation; ?> has-sidebar">
 		<div class="main-content content-main">
 
-			<?php if ( is_page( 'hayden' ) ) : ?>
-				<div class="location-extra-content-top" style="padding: 1em 0;margin: 0;color: #008700;font-weight: 600;">
-					<p style="margin-bottom: 0 !important;">
-						<strong style="font-weight: 900;">Hayden is closed for renovation.</strong>
-						For details on collections and services and <br>a preview of the new space, see <a href="/future-spaces/" style="color: #008700;">Hayden Renovation »</a>
-					</p>
-				</div>
-			<?php endif; ?>
-
 			<?php
 			if ( '' != $title1 || '' != $title2 ) :
 				$noTab = '';

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.11.0-alpha1-@@branch-@@commit
+Version: 1.11.1-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/inc/homepage-hours.php
+++ b/inc/homepage-hours.php
@@ -23,7 +23,7 @@
 <div class="location">
 	<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours">Closed for renovation</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
+		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today</div><div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
 	</div>
 </div>
 <div class="location-hayden-reno">

--- a/page-main-locations.php
+++ b/page-main-locations.php
@@ -154,9 +154,6 @@ get_header(); ?>
 								<?php echo $phone ?>
 								<br/>
 								<?php endif; ?><a class="map" data-target="<?php echo $locationId; ?>" href="#!<?php echo $slug; ?>">Map: <?php echo $building ?></a>
-								<?php if ( 'hayden-library' === $slug ) : ?>
-									<br/><span style="margin-bottom: 0 !important; font-weight: 600;"><a href="/future-spaces/" style="color: #008700;">Hayden closed for renovation until Fall 2020 »</a></span>
-								<?php endif; ?>
 								<?php if ( $study24 == 1 ) : ?>
 									<br/>
 									<a class="space247" href="<?php echo $gStudy24Url; ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>

--- a/page-study-spaces.php
+++ b/page-study-spaces.php
@@ -111,42 +111,37 @@ get_header(); ?>
 										<?php endif; ?>
 									</div>
 									<div class="study-space--info">
-										<?php if ( 'hayden-library' === $slug ) : ?>
-											<div class="ss-item" style="border-right: none;">Great new study spaces coming to Hayden - see: <a href="/future-spaces/">Hayden Renovation</a></div>
-										<?php else : ?>
-											<div class="ss-1 ss-item">
-											
-												<h4><?php echo $subject ?></h4>
-												<div class="sub">
-													<?php if ( $phone != '' ) : ?>
-													<?php echo $phone ?><br/>
-													<?php endif; ?>
-													Show on map: <br><a href="/locations/#!<?php echo $slug; ?>"><?php echo $building ?></a><br/>
-													<?php if ( get_the_title() !== 'Information Intersection at Stata Center' ) : ?>
-														<span class="hours">Open today<br/>
-														<span data-location-hours="<?php the_title(); ?>"></span></span>
-													<?php
-														endif;
-														if ( $reserveUrl != '' ) :
-													?>
-													<a class="mobileReserve visible-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
-													<?php endif; ?>
-												</div>
+										<div class="ss-1 ss-item">
+											<h4><?php echo $subject ?></h4>
+											<div class="sub">
+												<?php if ( $phone != '' ) : ?>
+												<?php echo $phone ?><br/>
+												<?php endif; ?>
+												Show on map: <br><a href="/locations/#!<?php echo $slug; ?>"><?php echo $building ?></a><br/>
+												<?php if ( get_the_title() !== 'Information Intersection at Stata Center' ) : ?>
+													<span class="hours">Open today<br/>
+													<span data-location-hours="<?php the_title(); ?>"></span></span>
+												<?php
+													endif;
+													if ( $reserveUrl != '' ) :
+												?>
+												<a class="mobileReserve visible-phone" href="<?php echo $reserveUrl; ?>"><?php echo $reserveText; ?></a>
+												<?php endif; ?>
 											</div>
+										</div>
 
-											<?php if ( $individual != '' ) : ?>
-											<div class="ss-2 ss-item">
-												<h4>Total seats</h4>
-												<?php echo $individual; ?>
-											</div>
-											<?php endif; ?>
-											
-											<?php if ( $spaces != '' ) : ?>
-											<div class="ss-3 ss-item last">
-												<h4>Group spaces</h4>
-												<?php echo $spaces; ?>
-											</div>
-											<?php endif; ?>
+										<?php if ( $individual != '' ) : ?>
+										<div class="ss-2 ss-item">
+											<h4>Total seats</h4>
+											<?php echo $individual; ?>
+										</div>
+										<?php endif; ?>
+
+										<?php if ( $spaces != '' ) : ?>
+										<div class="ss-3 ss-item last">
+											<h4>Group spaces</h4>
+											<?php echo $spaces; ?>
+										</div>
 										<?php endif; ?>
 									</div>
 								</div>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.11.0-alpha1-@@branch-@@commit
+Version: 1.11.1-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
#### Why are these changes being introduced:

* Hayden is preparing to re-open after its renovation, so closure
  information needs to be removed from the theme where it was added.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/UXWS-1162

#### How does this address that need:

* This removes four hard-coded closure notices from the parent theme:
  - The locations template page (the green text above the tabbed UI)
  - The list of locations on the map display (below the Hayden entry)
  - The front page locations list (when that is active - it is not now)
  - The study spaces list (when that is active - it is not now in production, but is on staging)

#### Document any side effects to this change:

* This bumps the theme version string in style.css and css/style.css
  to 1.11.1
* This is generally a reversion of PR #311 - but betweeen that original
  implementation and now, the homepage location information has been
  moved to a separate partial, inc/homepage-hours - so these PRs will
  not align perfectly. Additionally, some parts of these notices were
  added before that PR, so things are messier than I would prefer.

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
