### PR TITLE
Adds Location 2021 page template

### DIFF
--- a/content-location-2021.php
+++ b/content-location-2021.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * The template for displaying location post information in a single display.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.12.0
+ */
+
+global $gStudy24Url;
+
+$mapPage = '/locations/#!';
+
+$locationId = get_the_ID();
+$slug       = $post->post_name;
+
+$subject  = cf( 'subject' );
+$phone    = cf( 'phone' );
+$email    = cf( 'email' );
+$building = cf( 'building' );
+$spaces   = cf( 'group_spaces' );
+$arexpert = get_field( 'expert' );
+
+$content_top_2021 = get_field( 'content_top_2021' );
+
+$content1left = get_field( 'tab_1_content_left' );
+$content1     = get_field( 'tab_1_content' );
+
+$content1wide = 0;
+if ( '' === $content1 ) {
+	$content1wide = 1;
+}
+
+$study24 = get_field( 'study_24' );
+
+$expertAskUrl = get_field( 'expert_ask_url' );
+if ( '' === $expertAskUrl ) {
+	$expertAskUrl = 'http://libraries.mit.edu/ask';
+}
+
+// Populate the array of available main images.
+$numMain = 6;
+$arMain  = array();
+for ( $i = 1;$i <= $numMain;$i++ ) {
+	$img = get_field( 'main_image' . $i, $locationId );
+	if ( '' !== trim( $img ) ) {
+		$arMain[] = $img;
+	}
+}
+
+// Populate the array of available sub images.
+$numSub = 8;
+$arSub  = array();
+$subs   = 0;
+for ( $i = 1;$i <= $numSub;$i++ ) {
+	$img = get_field( 'sub_image' . $i, $locationId );
+	if ( '' !== trim( $img ) ) {
+		$subs++;
+		$arSub[] = $img;
+	}
+}
+
+$strLocation = '';
+if ( 0 >= $subs ) {
+	$strLocation = 'noThumbs';
+}
+
+$alertTitle   = cf( 'alert_title' );
+$alertContent = cf( 'alert_content' );
+?>
+
+<div class="libraryAlertTop">
+	<?php
+	require locate_template( 'inc/alert.php' );
+	if ( 0 === $showAlert && '' !== $alertTitle ) {
+		echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . $alertTitle . '</h3>' . '<p>' . $alertContent . '</p>' . '</div>' . '</div>' . '</div>';
+	}
+	?>
+</div>				
+	<div class="title-page libraryTitle flex-container">
+		<div class="topLeft">
+			<div class="libraryContent">
+				<h1>
+					<span class="libraryName"><?php the_title(); ?></span>
+					<span class="subject-library"><?php echo $subject; ?></span>
+				</h1>
+				<div class="info-more">
+					<a href="tel:<?php echo $phone; ?>" class="phone"><?php echo $phone; ?></a> |
+						<?php if ( $email ) : ?>
+					<a href="mailto:<?php echo $email; ?>" class="email"><?php echo $email; ?></a> |
+						<?php endif; ?>
+					<a href="<?php echo $mapPage . $slug; ?>">Room: <?php echo $building; ?> <i class="icon-arrow-right"></i></a>
+				</div>
+			</div><!-- end div.libraryContent -->
+
+			<div class="hours-today">
+				<span>Today's hours: <strong data-location-hours="<?php the_title(); ?>"></strong></span>
+				<?php if ( 1 === $study24 ) : ?>
+					| <a class="study-24-7" href="<?php echo $gStudy24Url; ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
+				<?php endif; ?>
+				<a href="/hours" class="link-hours-all">See all hours <i class="icon-arrow-right"></i></a>
+			</div><!-- end div.hours-today -->
+		</div><!-- end div.topLeft -->
+		<div class="topRight">
+			<div class="library-image">
+				<?php
+					$val = $arMain[ array_rand( $arMain ) ];
+				?>
+				<?php if ( '' !== $val ) : ?>
+					<img src="<?php echo $val; ?>" data-thumb="<?php echo $val; ?>" alt="<?php the_title(); ?>" />
+				<?php endif; ?>
+			</div><!-- end div.library-image -->
+		</div><!-- end div.topRight -->
+	</div><!-- end div.libraryTitle -->
+
+	<div id="content" class="content <?php echo $strLocation; ?>">
+		<div class="main-content content-main">
+			<div class="tabcontent group noTab">
+				<div class="tab tab1 active flex-container group" id="tab1">
+
+					<div class="flex-item first group <?php if ( $content1wide ) : ?>span7 wideColumn<?php else : ?>span4<?php endif; ?>">
+
+						<?php
+							if ( $arexpert ) {
+								$expertIndex = array_rand( $arexpert );
+								$expert = $arexpert[ $expertIndex ];
+
+
+								$name = $expert->post_title;
+								$bio = $expert->post_excerpt;
+								// $url = $expert->guid;
+								$url = get_post_meta( $expert->ID, 'expert_url', 1 );
+
+								if ( has_post_thumbnail( $expert->ID ) ) {
+									$thumb = get_the_post_thumbnail( $expert->ID, array( 108, 108 ) );
+								} else {
+									$thumb = '';
+								}
+
+						?>
+						<div class="profile-content">
+							<?php if ( '' !== $thumb ) :
+								echo $thumb;
+							endif; ?>
+							<div class="profile-content__body">
+								<h3>
+									<span class="intro">Featured expert</span>
+									<span class="name"><?php echo $name; ?></span>
+									<span class="bio"><?php echo $bio; ?></span>
+								</h3>
+								<div class="links">
+									<a class="primary" href="<?php echo $url; ?>" target="_blank">How can I help? <i class="icon-arrow-right"></i></a>
+									<a href="/experts">See all our experts <i class="icon-arrow-right"></i></a>
+								</div>
+
+							</div>
+
+						</div>
+
+						<?php
+							}
+								echo $content1left;
+							?>
+
+					</div>
+
+					<div class="flex-item second span3">
+						<?php echo $content_top_2021; ?>
+						<?php echo $content1; ?>
+					</div>
+
+				</div>
+			</div><!-- end div.tabcontent -->
+		</div><!-- end div.col-1 -->

--- a/content-location.php
+++ b/content-location.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying location post information.
+ * The template for displaying location post information in a tabbed layout.
  *
  * @package MIT_Libraries_Parent
  * @since 1.2.1

--- a/css/partials/_locations.scss
+++ b/css/partials/_locations.scss
@@ -74,6 +74,38 @@
 			}
 }
 
+// The 2021 location template adjusts column widths because the sidebar is not
+// loaded.
+.locationPage.page-template-page-location-2021 {
+	// This matches the left-margin that is used throughout the site.
+	.main-content {
+		padding-right: 27.5px;
+	}
+	.tab {
+		.first {
+			@include bp-tablet--portrait {
+				width: 33%;
+			}
+		}
+		.second {
+			@include bp-tablet--portrait {
+				width: 66%;
+			}
+			// This overrides default .alignleft styling which has 1em top
+			// margin.
+			img.alignleft {
+				margin-top: 0;
+			}
+		}
+	}
+	// This repeats a media-queried rule from _tabs.scss, for all screens.
+	.tabcontent {
+		border-top: 1px solid #dedede;
+		padding-top: 20px;
+		clear: both;
+	}
+}
+
 .page-locations {
 	.location-name {
 		padding-bottom: 15px;

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.11.1-@@branch-@@commit
+Version: 1.12.0-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/functions.php
+++ b/functions.php
@@ -501,7 +501,7 @@ function twentytwelve_body_class( $classes ) {
 		$classes[] = 'boxSizingOn';
 	}
 
-	if ( is_page_template( 'page-location.php' ) ) {
+	if ( is_page_template( 'page-location.php' ) || is_page_template( 'page-location-2021.php' ) ) {
 		$classes[] = 'locationPage';
 	}
 

--- a/page-location-2021.php
+++ b/page-location-2021.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Template Name: Location (2021) Template
+ *
+ * This is the template that displays location records according to a new
+ * page layout that was developed in 2021 as a result of the Hayden library
+ * renovation.
+ *
+ * It does not display the standard sidebar, and the corresponding content
+ * template (content-location-2021) does not use a tabbed layout.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.12.0
+ */
+
+$pageRoot = getRoot( $post );
+$section = get_post( $pageRoot );
+$isRoot = $section->ID == $post->ID;
+
+get_header(); ?>
+
+<?php get_template_part( 'inc/breadcrumbs' ); ?>
+
+<?php
+$objs = get_field( 'page_location' );
+
+$args = array(
+	'p' => $objs->ID,
+	'post_type' => 'any',
+);
+
+$location_posts = new WP_Query( $args );
+?>
+
+<div id="stage" class="inner" role="main">
+
+	<?php
+	while ( $location_posts->have_posts() ) :
+		$location_posts->the_post();
+		?>
+
+		<?php get_template_part( 'content', 'location-2021' ); ?>
+
+	<?php endwhile; // end of the loop. ?>
+
+</div>
+
+<?php get_footer(); ?>

--- a/page-location.php
+++ b/page-location.php
@@ -2,10 +2,9 @@
 /**
  * Template Name: Location Template
  *
- * This is the template that displays all pages by default.
- * Please note that this is the WordPress construct of pages
- * and that other 'pages' on your WordPress site will use a
- * different template.
+ * This is the template that displays location records, which have a number
+ * of custom fields defined by the ACF plugin. This template was designed
+ * prior to 2021, and is a legacy layout.
  *
  * @package MIT_Libraries_Parent
  * @since 1.2.1

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.11.1-@@branch-@@commit
+Version: 1.12.0-@@branch-@@commit
 
 MIT Libraries theme built for the MIT Libraries website.
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This introduced a new page template to the theme, "Location (2021)". This is a new option for formatting a library location page, with these differences:
1. The right sidebar (populated by widgets) is not displayed.
2. The tabbed display is abandoned, making all "tab2" fields invisible.
3. A new field, "content_2021_top" is supported above the existing fields.
4. Some stylistic changes are introduced, such as a horizontal border between page top and page content, and a thicker right margin.

#### Helpful background context (if appropriate)

This is discussed in greater depth in the linked Jira ticket.

#### How can a reviewer manually see the effects of these changes?

You can see the new template in action on the staging site, for the Hayden page.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1205

#### Todo:
- [X] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
No, HOWEVER:

This change should be deployed in conjunction with configuration changes to the Advanced Custom Fields plugin. These are detailed in the commit message, but I'm open to adding them somewhere more sustainable. I'd love to hear options for this.
