### PR TITLE
Updates to Location 2021 template

### DIFF
--- a/content-location-2021.php
+++ b/content-location-2021.php
@@ -165,7 +165,6 @@ $alertContent = cf( 'alert_content' );
 
 					<div class="flex-item second span3">
 						<?php echo $content_top_2021; ?>
-						<?php echo $content1; ?>
 					</div>
 
 				</div>

--- a/css/partials/_locations.scss
+++ b/css/partials/_locations.scss
@@ -88,13 +88,19 @@
 			}
 		}
 		.second {
+			max-width: 540px;
 			@include bp-tablet--portrait {
 				width: 66%;
 			}
-			// This overrides default .alignleft styling which has 1em top
-			// margin.
-			img.alignleft {
-				margin-top: 0;
+
+			.featured-location {
+				margin-top: 36px;
+
+				// This overrides default .alignleft styling which has 1em top
+				// margin.
+				img.alignleft {
+					margin-top: 0;
+				}
 			}
 		}
 	}
@@ -306,6 +312,18 @@
 }
 
 /* ---- Responsive Styles ---- */
+@media screen and (max-width: 820px) {
+	.page-template-page-location-2021 {
+		.second {
+			.featured-location {
+				.alignleft {
+					float: inherit;
+				}
+			}
+		}
+	}
+}
+
 @media screen and (min-width: 569px) and (max-width: 820px) {
 	.locationPage {
 		.profile-content {


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This makes a few updates to the new location template that was introduced in release 1.12.0. Specifically:

* It removes the no-longer-needed tab-1-right field from being rendered.
* It adds a max-width rule to the right column, capping it at 540 pixels.
* It adds support for a new class, `featured-location`, to control how those content blocks  behave on a few page widths.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to the staging site.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/uxws-1205

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
