### PR TITLE
Update accounts link on mobile header

### DIFF
--- a/inc/nav-smalldisplays.php
+++ b/inc/nav-smalldisplays.php
@@ -13,7 +13,7 @@
 	<span class="bottom">Search</span>
 </a><!-- End /search -->
 
-<a href="/barton-account" class="link-account hidden-non-mobile">
+<a href="/accounts" class="link-account hidden-non-mobile">
 	<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="15.4" height="16" viewBox="0 0 15.4 16" enable-background="new 0 0 15.445 16" xml:space="preserve" class="icon-account"><path d="M13.4 15.7C12.2 15.9 10.4 16 7.7 16c-5.4 0-7.3-0.6-7.3-0.6 -0.3-0.1-0.4-0.4-0.4-0.7 0.3-1.6 1.2-2.5 2.5-3.3 0.3-0.2 0.8-0.4 1.2-0.6 0.8-0.3 1.8-0.7 2-1.3C5.8 9.2 5.7 8.6 5.2 7.9c-1.4-2.3-1.7-4.3-0.8-5.9C5.1 0.7 6.4 0 7.7 0c1.4 0 2.6 0.7 3.3 2 0.9 1.6 0.7 3.6-0.8 5.9C9.8 8.6 9.6 9.2 9.8 9.6c0.2 0.6 1.2 1 2 1.3 0.4 0.2 0.9 0.4 1.2 0.6 1.2 0.8 2.1 1.6 2.5 3.3 0.1 0.3-0.1 0.6-0.4 0.7C15 15.4 14.5 15.6 13.4 15.7"/></svg>
 	<span class="bottom">Account</span>
 </a><!-- End /barton-account -->


### PR DESCRIPTION
#### What does this PR do?
This updates the link to the accounts page on the mobile header template, which was missed when we launched Alma originally.

#### Helpful background context (if appropriate)
This theme uses `header.php` to build both the `head` element of every page load, as well as to build the top elements of the `body` element (The body tag itself, a skip link, the opening of `div.wrap-page`, and the `header` element.

That header tag loads a number of other partials, including `inc/nav-main` for the full width navigation, but _also_ a separate partial for mobile navigation, `inc/nav-smalldisplays`.

#### How can a reviewer manually see the effects of these changes?
This change has been deployed to the staging site.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1293

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
