### PR TITLE
Adds page customization metabox to theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1054,3 +1054,33 @@ function ssl_srcset( $sources ) {
 	return $sources;
 }
 add_filter( 'wp_calculate_image_srcset', 'ssl_srcset' );
+
+/**
+ * Start a block of functions that implement a metabox on the page editing
+ * screen.
+ */
+if ( ! function_exists( 'mitlib_page_customization_meta' ) ) {
+	/**
+	 * Adds a meta box to the page editing screen
+	 */
+	function mitlib_page_customization_meta() {
+		add_meta_box( 'mitlib_page_customization_meta', __( 'Page Customization', 'prfx-textdomain' ), 'mitlib_page_customization_meta_callback', 'page', 'side', 'high' );
+	}
+}
+add_action( 'add_meta_boxes', 'mitlib_page_customization_meta' );
+
+if ( ! function_exists( 'mitlib_page_customization_meta_callback' ) ) {
+	/**
+	 * Outputs the content of the meta box
+	 *
+	 * @param object $post unused.
+	 */
+	function mitlib_page_customization_meta_callback( $post ) {
+		$post = null; // Wipe Unused argument.
+		echo 'To customize the breadcrumb and the link to the top-level category at the top of the page, see the <strong>Categories</strong> box below.';
+	}
+}
+/**
+ * End the functions which implement the customization metabox on the page
+ * editing screen.
+ */


### PR DESCRIPTION
#### Why are these changes being introduced:

We currently have a plugin whose only purpose is to create a metabox
with instructions about how to control breadcrumbs on pages. The
actual functionality of the breadcrumb is implemented by this theme,
however. It makes more sense for the metabox to be part of the theme
as well.

Additionally, making this change will allow us to retire the [MITlib Page
Customization Metabox](https://github.com/MITLibraries/mitlib-page-customization-metabox) plugin.

#### Relevant ticket(s):

There is no specific ticket, but the opportunity for this became clear as part of https://mitlibraries.atlassian.net/browse/ENGX-138

#### How does this address that need:

This moves the two functions which create the metabox into the theme
functions.php file, wrapped in checks for whether the plugin has
already created them.

#### Document any side effects to this change:

The functions.php file - currently over 1,000 lines long - will get a
bit longer and messier. Ultimately these functions could be their own
class, but no other classes exist in this theme yet, so I'm not sure
if this is the place to start that process.

#### Requires new or updated plugins, themes, or libraries?
NO - although after this merges and is deployed, we'll be able to retire a plugin

#### Requires change to deploy process?
NO
