### PR TITLE
More permissive check for showing location alerts

### DIFF
--- a/content-location-2021.php
+++ b/content-location-2021.php
@@ -71,7 +71,7 @@ $alertContent = cf( 'alert_content' );
 <div class="libraryAlertTop">
 	<?php
 	require locate_template( 'inc/alert.php' );
-	if ( 0 === $showAlert && '' !== $alertTitle ) {
+	if ( 0 == $showAlert && '' !== $alertTitle ) {
 		echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . $alertTitle . '</h3>' . '<p>' . $alertContent . '</p>' . '</div>' . '</div>' . '</div>';
 	}
 	?>


### PR DESCRIPTION
#### Why are these changes being introduced:

* The most recent location template - introduced last fall in #344 - uses too
  strict a comparison to determine whether a location alert will be
  shown - the === operator used is different from that used by the older
  location template (which uses ==). I didn't realize initially the
  using the stricter comparison would never result in the alert being
  shown, it seems.

Compare the new location template at https://github.com/MITLibraries/MITlibraries-parent/blob/main/content-location-2021.php#L74
with the older template at https://github.com/MITLibraries/MITlibraries-parent/blob/main/content-location.php#L97

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1368

#### How does this address that need:

* This change reverts the new location template to using the more
  permissive == operator instead of ===.

#### Document any side effects to this change:

* I'm still not entirely sure about how the logic of this check works,
  so there may be some aspect - but I doubt it. This reverts to the same
  comparison that is working for the other location template.
* As expected, CodeClimate is flagging the use of the == operator  - which is why I originally changed this check in the first place. That's going to have to be accepted for now.

#### How can a reviewer manually see the effects of these changes?

This branch is current present on the staging server. If you look at the Hayden Library page, you'll note a location alert being shown about the elevators being out of service.

#### Screenshots (if appropriate)
Staging (showing location alert)
![Screen Shot 2022-05-03 at 3 55 48 PM](https://user-images.githubusercontent.com/1403248/166555605-594aee45-e648-49ab-a368-e8d7deced255.png)

Production (without alert)
![Screen Shot 2022-05-03 at 3 56 11 PM](https://user-images.githubusercontent.com/1403248/166555661-3d285a1b-7ee6-47b2-a6a2-b5680d7702a4.png)

#### Todo:

- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
