### PR TITLE
Convert content below hours grid to a widget area

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -353,6 +353,15 @@ function mitlib_widgets_init() {
 		'after_title'   => '</h2>',
 	) );
 
+	register_sidebar( array(
+		'name'          => __( 'Below Hours Grid Area', 'twentytwelve' ),
+		'id'            => 'sidebar-below-hours-grid',
+		'description'   => __( 'Appears below the grid of library hours, allowing for widgets to describe locations that do not appear on the grid.', 'twentytwelve' ),
+		'before_widget' => '<aside id="%1$s" class="widget %2$s locations-more" role="complementary">',
+		'after_widget'  => '</aside>',
+		'before_title'  => '<h3 class="widget-title">',
+		'after_title'   => '</h3>',
+	) );
 }
 add_action( 'widgets_init', 'mitlib_widgets_init' );
 

--- a/page-hours-json.php
+++ b/page-hours-json.php
@@ -376,23 +376,10 @@ $next = '';
 	</table>
 	
 	<!-- TABLE ENDS -->
-	
-		<div class="locations-more">
-			<h3>Locations without hours</h3>
-			<!-- Building 9 -->
-			<h4>Building 9 book drop</h4>
-			<p><a href="/locations/#!building-9">Map:&nbsp; 9-Samuel Tak Lee Building</a></p>
-			<!-- DIRC -->
-			<h4><a href="/dirc">Digital Instruction Resource Center (DIRC)</a></h4>
-			<p><a href="/locations/#!digital-instruction-resource-center-dirc">Map:&nbsp; 14N-132</a></p>
-			<!-- STATA -->
-			<h4>Stata Center Book Drop</h4>
-			<p><a href="/locations/#!stata">Map:&nbsp;  32-Student Street</a></p>
-			<!-- Physics Reading Room -->
-			<h4>Physics Reading Room</h4>
-			<p>Building 4-332 | 617.253.1791<br>
-			<a href="mailto:jytqtran@mit.edu">Tan-Quy Tran</a>, Reading Room Assistant</p>
-		</div>  <!-- end div.locations-more -->
+
+	<?php if ( is_active_sidebar( 'sidebar-below-hours-grid' ) ) : ?>
+		<?php dynamic_sidebar( 'sidebar-below-hours-grid' ); ?>
+	<?php endif; ?>
 
 	</div> <!-- end .content-page -->
 </div> <!-- end #content -->


### PR DESCRIPTION
#### Why are these changes being introduced:

* As the Libraries have re-opened, there have been a number of changes
  to the currently-static-HTML content below the hours grid. In order to
  allow us to change this content more responsively as the organization
  evolves, this converts that static content into a widget area so that
  changes don't require code updates.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1367

#### How does this address that need:

* This takes out the static content from `page-hours-json.php` and
  replaces it with a new sidebar area. As part of the deploy of this, I
  will create and populate a widget with the static content.

#### Document any side effects to this change:

* The actual markup around this content will change, but not in a way
  that will be visible to the user or a search engine.

#### How can a reviewer manually see the effects of these changes?

As I write this, the branch is currently not deployed anywhere - so if you have a local network you can look at it there. If not, then I'll be deploying this to staging once #353 is through code review.

#### Screenshots (if appropriate)

Here's the current production hours page...
![Screen Shot 2022-05-03 at 4 41 26 PM](https://user-images.githubusercontent.com/1403248/166562422-0b439d10-7c39-4395-b42d-b28f2a65a12d.png)

Converting that "Locations without hours" block to a widget area will momentarily cause it to disappear (this is from staging, after deploying the branch and before creating the new widget)
![Screen Shot 2022-05-03 at 4 28 05 PM](https://user-images.githubusercontent.com/1403248/166562519-b2216258-7ac1-4e33-9aee-4923c6e56047.png)

After the widget has been defined (taking care to remove the bit about the Physics reading room that motivated this entire ticket), the page looks like this:
![Screen Shot 2022-05-04 at 9 57 18 AM](https://user-images.githubusercontent.com/1403248/166696895-95ff97bf-4cf8-46b3-b453-c305d01d87a1.png)


#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
