### PR TITLE
Updates to frontpage styling and content

### DIFF
--- a/css/partials/_home.scss
+++ b/css/partials/_home.scss
@@ -47,7 +47,6 @@ body.page-home {
 		display: flex;
 		flex-direction: column;
 		h2 {
-			border-bottom: 1px solid $color-secondary;
 			text-align: left;
 			@include bp-tablet--portrait {
 				padding: 0.5em .5em 0.25em;
@@ -294,7 +293,6 @@ body.page-home {
 				margin: 8px;
 				.widget-title {
 					color: white;
-					border-bottom: 1px solid white;
 					padding: 9px 9px 0 9px;
 				}
 				.textwidget {

--- a/guide-list.html
+++ b/guide-list.html
@@ -28,10 +28,10 @@
 </ul>
 <ul class="guide-list-4">
 	<li><a href="http://libguides.mit.edu/gis" class="button-secondary--magenta">Geographic information systems (GIS)</a></li>
-	<li><a href="http://libguides.mit.edu/aero" class="button-secondary--magenta">Aeronautics/astronautics</a></li>
+	<li><a href="http://libguides.mit.edu/aero-astro" class="button-secondary--magenta">Aeronautics/astronautics</a></li>
 	<li><a href="http://libguides.mit.edu/patents" class="button-secondary--magenta">Patents</a></li>
 	<li><a href="http://libguides.mit.edu/physics" class="button-secondary--magenta">Physics</a></li>
-	<li><a href="http://libguides.mit.edu/market" class="button-secondary--magenta">Market research</a></li>
+	<li><a href="http://libguides.mit.edu/business" class="button-secondary--magenta">Market research</a></li>
 	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
 </ul>
 <ul class="guide-list-5">


### PR DESCRIPTION
#### Why are these changes being introduced:

* The frontpage loads a random collection of libguides to show to the
  user. While those guides have been stable over years, two of them
  recently changed their URLs.
* Separately, there is a request to remove some lines from the hours and locations sidebar on the frontpage.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1366 (libguides links)
* https://mitlibraries.atlassian.net/browse/uxws-1364 (hours and locations sidebar)

#### How does this address that need:

* This updates the curated set of guides that this theme stores with the
  current URLs.
* I considered some deeper changes to this feature, including:
  * Widgetizing the area and loading one widget at random
  * Loading guide information from the libguides API
  * Creating a custom post type for guides, similar to how we handle
    expert profiles, and loading those at random using similar JS
  Each of those would involve more engineering work than I think is
  warranted at the moment (given that this is the first change in
  several years). However, if more changes start coming then each of
  these could be more viable than a static HTML document in the theme.
* The CSS for the hours and locations sidebar has been updated to remove two declarations of a bottom border.

#### Document any side effects to this change:

* None, but we are choosing to continue using a hard-to-update feature
  of the theme.

#### How can a reviewer manually see the effects of these changes?

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
