### PR TITLE
Update libchat.js to use new URL format

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries
 Author: Lightning Trumpet
 Author URI: http://wordpress.org/
-Version: 1.13.1-@@branch-@@commit
+Version: 1.13.2-@@branch-@@commit
 MIT Libraries theme built for the MIT Libraries website.
 */
 

--- a/js/libs/libchat.js
+++ b/js/libs/libchat.js
@@ -1,3 +1,3 @@
 $(function(){
-   $.getScript('//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88');
+   $.getScript('https://libanswers.mit.edu/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88');
 });


### PR DESCRIPTION
** Why are these changes being introduced:

* Springshare is deprecating the URL pattern we have used previously when loading their javascript-based chat integration. The new URL pattern makes use of our custom doman name, rather than a generic domain across all customers.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1423

** How does this address that need:

* This updates libchat.js in the parent theme to use the new URL pattern
* The theme version is bumped because of this change, to 1.13.2.

** Document any side effects to this change:

* I'm choosing to include the https protocol now, rather than the protocol-agnostic `//` prefix. The Springshare documentation uses the protocol in their examples, and it seems safe to explicitly call for https at this point.

## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
Why are we making these changes? Is there more work to be done to fully
achieve these goals?

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-

#### Screenshots (if appropriate)

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
