### PR TITLE
Adds role-specific styles for content debugging

### DIFF
--- a/css/super-admin.css
+++ b/css/super-admin.css
@@ -1,0 +1,23 @@
+/* Links to the production URL are in green, and change the cursor to warn against clicking them. */
+body.admin-bar a[href^="https://libraries."],
+body.admin-bar a[href^="http://libraries."] {
+  border: 5px solid green;
+  cursor: not-allowed;
+}
+
+body.admin-bar img[src^="https://libraries."],
+body.admin-bar img[src^="http://libraries."] {
+	border: 5px solid green;
+  cursor: not-allowed;
+}
+
+/* Links to non-productions URLs are thicker and red, to be annoying and force changes. */
+body.admin-bar a[href^="https://libraries-"],
+body.admin-bar a[href^="http://libraries-"] {
+  border: 10px solid red;
+}
+
+body.admin-bar img[src^="https://libraries-"],
+body.admin-bar img[src^="http://libraries-"] {
+	border: 10px solid red;
+}

--- a/functions.php
+++ b/functions.php
@@ -130,6 +130,8 @@ function twentytwelve_scripts_styles() {
 
 	wp_register_style( 'jquery.smartmenus.bootstrap', '/css/bootstrap-css/jquery.smartmenus.bootstrap.js', false, false );
 
+	wp_register_style( 'super-admin', get_template_directory_uri() . '/css/super-admin.css', array(), $theme_version, false );
+
 	/*
 	 * Loads the Internet Explorer specific stylesheet.
 	 */
@@ -226,6 +228,9 @@ function twentytwelve_scripts_styles() {
 		wp_enqueue_script( 'bootstrap-js' );
 	}
 
+	if ( is_super_admin() ) {
+		wp_enqueue_style( 'super-admin' );
+	}
 }
 
 add_action( 'wp_enqueue_scripts', 'twentytwelve_scripts_styles' );


### PR DESCRIPTION
### Why are these changes being introduced:

There are lingering pieces of content across the WordPress network with hard-coded domain names, either to our legacy production site or to our staging site.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-211

### How does this address that need:

* This creates a new stylesheet in the parent theme which adds a noticeable border to any content that is loaded from (or links to) legacy domain names.
* The stylesheet is registered in a way that allows it to be loaded from the parent or child themes.
* The stylesheet is only enqueued for users in the Super Admin role, which would allow it to be in place on an ongoing basis, beyond this migration.

### Screenshot

![Screen Shot 2023-02-14 at 10 19 33 AM](https://user-images.githubusercontent.com/1403248/218780454-01dfd39f-d22f-422f-a2bf-9145eebab9e1.png)

### Document any side effects to this change:

* There is one additional asset being managed by the theme, although these limits are less relevant now.
* This feature can probably be reverted after migration, but that can be a ticket for future-us.

#### Todo:
- [ ] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
